### PR TITLE
Added posix_fallocate support

### DIFF
--- a/pjdfstest.c
+++ b/pjdfstest.c
@@ -113,6 +113,7 @@ enum action {
 #endif
 	ACTION_TRUNCATE,
 	ACTION_FTRUNCATE,
+	ACTION_POSIX_FALLOCATE,
 	ACTION_STAT,
 	ACTION_FSTAT,
 	ACTION_LSTAT,
@@ -196,6 +197,7 @@ static struct syscall_desc syscalls[] = {
 #endif
 	{ "truncate", ACTION_TRUNCATE, { TYPE_STRING, TYPE_NUMBER, TYPE_NONE } },
 	{ "ftruncate", ACTION_FTRUNCATE, { TYPE_DESCRIPTOR, TYPE_NUMBER, TYPE_NONE } },
+	{ "posix_fallocate", ACTION_POSIX_FALLOCATE, { TYPE_DESCRIPTOR, TYPE_NUMBER, TYPE_NUMBER, TYPE_NONE } },
 	{ "stat", ACTION_STAT, { TYPE_STRING, TYPE_STRING, TYPE_NONE } },
 	{ "fstat", ACTION_FSTAT, { TYPE_DESCRIPTOR, TYPE_STRING, TYPE_NONE } },
 	{ "lstat", ACTION_LSTAT, { TYPE_STRING, TYPE_STRING, TYPE_NONE } },
@@ -871,6 +873,9 @@ call_syscall(struct syscall_desc *scall, char *argv[])
 		break;
 	case ACTION_FTRUNCATE:
 		rval = ftruncate64(NUM(0), NUM(1));
+		break;
+	case ACTION_POSIX_FALLOCATE:
+		rval = posix_fallocate(NUM(0), NUM(1), NUM(2));
 		break;
 	case ACTION_STAT:
 		rval = stat64(STR(0), &sb);

--- a/pjdfstest.c
+++ b/pjdfstest.c
@@ -876,6 +876,10 @@ call_syscall(struct syscall_desc *scall, char *argv[])
 		break;
 	case ACTION_POSIX_FALLOCATE:
 		rval = posix_fallocate(NUM(0), NUM(1), NUM(2));
+		if (rval != 0) {
+			errno = rval;
+			rval = -1;
+		}
 		break;
 	case ACTION_STAT:
 		rval = stat64(STR(0), &sb);

--- a/tests/posix_fallocate/00.t
+++ b/tests/posix_fallocate/00.t
@@ -1,0 +1,58 @@
+#!/bin/sh
+# $FreeBSD: head/tools/regression/pjdfstest/tests/ftruncate/00.t 219439 2011-03-09 23:11:30Z pjd $
+
+desc="ftruncate descrease/increase file size"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+
+echo "1..21"
+
+n0=`namegen`
+n1=`namegen`
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+expect 0 create ${n0} 0644
+expect 0 open ${n0} O_RDWR : ftruncate 0 1234567
+expect 1234567 lstat ${n0} size
+expect 0 open ${n0} O_WRONLY : ftruncate 0 567
+expect 567 lstat ${n0} size
+expect 0 unlink ${n0}
+
+dd if=/dev/random of=${n0} bs=12345 count=1 >/dev/null 2>&1
+expect 0 open ${n0} O_RDWR : ftruncate 0 23456
+expect 23456 lstat ${n0} size
+expect 0 open ${n0} O_WRONLY : ftruncate 0 1
+expect 1 lstat ${n0} size
+expect 0 unlink ${n0}
+
+# successful ftruncate(2) updates ctime.
+expect 0 create ${n0} 0644
+ctime1=`${fstest} stat ${n0} ctime`
+sleep 1
+expect 0 open ${n0} O_RDWR : ftruncate 0 123
+ctime2=`${fstest} stat ${n0} ctime`
+test_check $ctime1 -lt $ctime2
+expect 0 unlink ${n0}
+
+# unsuccessful ftruncate(2) does not update ctime.
+expect 0 create ${n0} 0644
+ctime1=`${fstest} stat ${n0} ctime`
+sleep 1
+expect EINVAL -u 65534 open ${n0} O_RDONLY : ftruncate 0 123
+ctime2=`${fstest} stat ${n0} ctime`
+test_check $ctime1 -eq $ctime2
+expect 0 unlink ${n0}
+
+# third argument should not affect permission.
+expect 0 open ${n0} O_CREAT,O_RDWR 0 : ftruncate 0 0
+expect 0 unlink ${n0}
+expect 0 chmod . 0777
+expect 0 -u 65534 open ${n0} O_CREAT,O_RDWR 0 : ftruncate 0 0
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/posix_fallocate/00.t
+++ b/tests/posix_fallocate/00.t
@@ -1,12 +1,12 @@
 #!/bin/sh
 # $FreeBSD: head/tools/regression/pjdfstest/tests/ftruncate/00.t 219439 2011-03-09 23:11:30Z pjd $
 
-desc="ftruncate descrease/increase file size"
+desc="posix_fallocate descrease/increase file size"
 
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..21"
+echo "1..26"
 
 n0=`namegen`
 n1=`namegen`
@@ -16,42 +16,42 @@ cdir=`pwd`
 cd ${n1}
 
 expect 0 create ${n0} 0644
-expect 0 open ${n0} O_RDWR : ftruncate 0 1234567
-expect 1234567 lstat ${n0} size
-expect 0 open ${n0} O_WRONLY : ftruncate 0 567
+expect 0 open ${n0} O_RDWR : posix_fallocate 0 0 567
 expect 567 lstat ${n0} size
+expect 0 open ${n0} O_WRONLY : posix_fallocate 0 0 1234567
+expect 1234567 lstat ${n0} size
 expect 0 unlink ${n0}
 
 dd if=/dev/random of=${n0} bs=12345 count=1 >/dev/null 2>&1
-expect 0 open ${n0} O_RDWR : ftruncate 0 23456
+expect 0 open ${n0} O_RDWR : posix_fallocate 0 20000 3456
 expect 23456 lstat ${n0} size
-expect 0 open ${n0} O_WRONLY : ftruncate 0 1
-expect 1 lstat ${n0} size
+expect 0 open ${n0} O_WRONLY : posix_fallocate 0 0 23456
+expect 23456 lstat ${n0} size
 expect 0 unlink ${n0}
 
-# successful ftruncate(2) updates ctime.
+# successful posix_fallocate(2) updates ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
 sleep 1
-expect 0 open ${n0} O_RDWR : ftruncate 0 123
+expect 0 open ${n0} O_RDWR : posix_fallocate 0 0 123
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
-# unsuccessful ftruncate(2) does not update ctime.
+# unsuccessful posix_fallocate(2) does not update ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
 sleep 1
-expect EINVAL -u 65534 open ${n0} O_RDONLY : ftruncate 0 123
+expect EINVAL open ${n0} O_WRONLY : posix_fallocate 0 0 0
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
 # third argument should not affect permission.
-expect 0 open ${n0} O_CREAT,O_RDWR 0 : ftruncate 0 0
+expect 0 open ${n0} O_CREAT,O_RDWR 0 : posix_fallocate 0 0 1
 expect 0 unlink ${n0}
 expect 0 chmod . 0777
-expect 0 -u 65534 open ${n0} O_CREAT,O_RDWR 0 : ftruncate 0 0
+expect 0 -u 65534 open ${n0} O_CREAT,O_RDWR 0 : posix_fallocate 0 0 1
 expect 0 unlink ${n0}
 
 cd ${cdir}


### PR DESCRIPTION
Here is a patch that adds support for posix_fallocate() to pjdfstest.  I copied pjdfstest/tests/ftruncate/00.t to create the first pass at posix_fallocate() tests.
#### References:
- https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=190765
