### PR TITLE
Add tests for utimensat(2)

### DIFF
--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -192,6 +192,11 @@ supported()
 			return 1
 		fi
 		;;
+	stat_st_birthtime)
+		if [ "${os}" != "FreeBSD" ]; then
+			return 1
+		fi
+		;;
 	esac
 	return 0
 }

--- a/tests/utimensat/00.t
+++ b/tests/utimensat/00.t
@@ -1,0 +1,32 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat changes timestamps on any type of file"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..32"
+
+n0=`namegen`
+n1=`namegen`
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+DATE1=1900000000 #Sun Mar 17 11:46:40 MDT 2030
+DATE2=1950000000 #Fri Oct 17 04:40:00 MDT 2031
+for type in regular dir fifo block char socket; do
+	create_file ${type} ${n0}
+	expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+	expect $DATE1 lstat ${n0} atime
+	expect $DATE2 lstat ${n0} mtime
+	if [ "${type}" = "dir" ]; then
+		expect 0 rmdir ${n0}
+	else
+		expect 0 unlink ${n0}
+	fi
+done
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/01.t
+++ b/tests/utimensat/01.t
@@ -1,0 +1,53 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat with UTIME_NOW will set the will set typestamps to now"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+
+echo "1..7"
+
+n0=`namegen`
+n1=`namegen`
+TIME_MARGIN=300		# Allow up to a 5 minute delta between the timestamps
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+
+create_file regular ${n0}
+old_mtime=`$fstest lstat ${n0} mtime`
+old_atime=`$fstest lstat ${n0} atime`
+sleep 1	# Ensure that future timestamps will be different than this one
+
+expect 0 open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_NOW 0 UTIME_NOW 0
+new_mtime=`$fstest lstat ${n0} mtime`
+new_atime=`$fstest lstat ${n0} atime`
+delta_mtime=$(( $new_mtime - $old_mtime ))
+delta_atime=$(( $new_atime - $old_atime ))
+
+if [ "$delta_mtime" -gt 0 ]; then
+	if [ "$delta_mtime" -lt $TIME_MARGIN ]; then
+		echo "ok 4"
+	else
+		echo "not ok 4 new mtime is implausibly far in the future"
+	fi
+else
+	echo "not ok 4 mtime was not updated"
+fi
+if [ "$delta_atime" -gt 0 ]; then
+	if [ "$delta_atime" -lt $TIME_MARGIN ]; then
+		echo "ok 5"
+	else
+		echo "not ok 5 new atime is implausibly far in the future"
+	fi
+else
+	echo "not ok 5 atime was not updated"
+fi
+ntest=$((ntest+2))
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/02.t
+++ b/tests/utimensat/02.t
@@ -1,0 +1,31 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat with UTIME_OMIT will leave the time unchanged"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..10"
+
+n0=`namegen`
+n1=`namegen`
+DATE1=1900000000 #Sun Mar 17 11:46:40 MDT 2030
+DATE2=1950000000 #Fri Oct 17 04:40:00 MDT 2031
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+create_file regular ${n0}
+orig_mtime=`$fstest lstat ${n0} mtime`
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 0 UTIME_OMIT 0
+expect $DATE1 lstat ${n0} atime
+expect $orig_mtime lstat ${n0} mtime
+
+expect 0 open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_OMIT $DATE2 0 0
+expect $DATE1 lstat ${n0} atime
+expect $DATE2 lstat ${n0} mtime
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/03.t
+++ b/tests/utimensat/03.t
@@ -1,0 +1,35 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat can update birthtimes"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+require stat_st_birthtime
+
+echo "1..12"
+
+n0=`namegen`
+n1=`namegen`
+DATE1=100000000 #Sat Mar  3 02:46:40 MST 1973
+DATE2=200000000 #Mon May  3 13:33:20 MDT 1976
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+create_file regular ${n0}
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE1 0 0
+expect $DATE1 lstat ${n0} atime
+expect $DATE1 lstat ${n0} mtime
+expect $DATE1 lstat ${n0} birthtime
+
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE2 0 $DATE2 0 0
+expect $DATE2 lstat ${n0} atime
+expect $DATE2 lstat ${n0} mtime
+expect $DATE1 lstat ${n0} birthtime
+
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/04.t
+++ b/tests/utimensat/04.t
@@ -1,0 +1,32 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat can set mtime < atime or vice versa"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..10"
+
+n0=`namegen`
+n1=`namegen`
+DATE1=100000000 #Sat Mar  3 02:46:40 MST 1973
+DATE2=200000000 #Mon May  3 13:33:20 MDT 1976
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+
+create_file regular ${n0}
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+expect $DATE1 lstat ${n0} atime
+expect $DATE2 lstat ${n0} mtime
+
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE2 0 $DATE1 0 0
+expect $DATE2 lstat ${n0} atime
+expect $DATE1 lstat ${n0} mtime
+
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/05.t
+++ b/tests/utimensat/05.t
@@ -1,0 +1,49 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat can follow symlinks"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..16"
+
+n0=`namegen`
+n1=`namegen`
+n2=`namegen`
+DATE1=1900000000 #Sun Mar 17 11:46:40 MDT 2030
+DATE2=1950000000 #Fri Oct 17 04:40:00 MDT 2031
+DATE3=1960000000 #Mon Feb  9 21:26:40 MST 2032
+DATE4=1970000000 #Fri Jun  4 16:13:20 MDT 2032
+DATE5=1980000000 #Tue Sep 28 10:00:00 MDT 2032
+DATE6=1990000000 #Sat Jan 22 02:46:40 MST 2033
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+
+create_file regular ${n0}
+ln -s ${n0} ${n2}
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+
+expect 0 open . O_RDONLY : utimensat 0 ${n2} $DATE3 0 $DATE4 0 AT_SYMLINK_NOFOLLOW
+expect $DATE1 lstat ${n0} atime
+expect $DATE2 lstat ${n0} mtime
+expect $DATE3 lstat ${n2} atime
+expect $DATE4 lstat ${n2} mtime
+
+expect 0 open . O_RDONLY : utimensat 0 ${n2} $DATE5 0 $DATE6 0 0
+expect $DATE5 lstat ${n0} atime
+expect $DATE6 lstat ${n0} mtime
+# If atime is disabled on the current mount, then ${n2}'s atime should still be
+# $DATE3.  However, if atime is enabled, then ${n2}'s atime will be the current
+# system time.  For this test, it's sufficient to simply check that it didn't
+# get set to DATE5
+test_check "$DATE5" -ne `"$fstest" lstat ${n2} atime`
+expect $DATE4 lstat ${n2} mtime
+
+expect 0 unlink ${n0}
+expect 0 unlink ${n2}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/06.t
+++ b/tests/utimensat/06.t
@@ -1,0 +1,41 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat with UTIME_NOW will work if the caller has write permission"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..13"
+
+n0=`namegen`
+n1=`namegen`
+UID_NOBODY=`id -u nobody`
+GID_NOBODY=`id -g nobody`
+UID_ROOT=`id -u root`
+GID_ROOT=`id -g root`
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+create_file regular ${n0} 0644
+# First check that nobody can't update the timestamps
+expect EACCES -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_NOW 0 UTIME_NOW 0
+
+# Now check that the owner can update the timestamps
+expect 0 chown ${n0} $UID_NOBODY $GID_NOBODY
+expect 0 chmod ${n0} 0444
+expect 0 -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_NOW 0 UTIME_NOW 0
+
+# Now check that the superuser can update the timestamps
+expect 0 -u $UID_ROOT open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_OMIT 0 UTIME_OMIT 0
+
+# Now check that anyone with write permission can update the timestamps
+expect 0 chown ${n0} $UID_ROOT $GID_ROOT
+expect 0 chmod ${n0} 0666
+expect 0 -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_NOW 0 UTIME_NOW 0
+
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/07.t
+++ b/tests/utimensat/07.t
@@ -1,0 +1,47 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat will work if the caller is the owner or root"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..17"
+
+n0=`namegen`
+n1=`namegen`
+DATE1=1900000000 #Sun Mar 17 11:46:40 MDT 2030
+DATE2=1950000000 #Fri Oct 17 04:40:00 MDT 2031
+UID_NOBODY=`id -u nobody`
+GID_NOBODY=`id -g nobody`
+UID_ROOT=`id -u root`
+GID_ROOT=`id -g root`
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+create_file regular ${n0} 0644 $UID_ROOT $GID_ROOT
+# First check that nobody can't update the timestamps
+expect EPERM -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_OMIT $DATE2 0 0
+expect EPERM -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 0 UTIME_OMIT 0
+expect EPERM -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+
+# Now check that a nonowner with write permission can't update the timestamps
+expect 0 chmod ${n0} 0666
+expect EPERM -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_OMIT $DATE2 0 0
+expect EPERM -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 0 UTIME_OMIT 0
+expect EPERM -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+
+# Now check that the owner can update the timestamps
+expect 0 chown ${n0} $UID_NOBODY $GID_NOBODY
+expect 0 chmod ${n0} 0444
+expect 0 -u $UID_NOBODY open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0
+
+# Now check that the superuser can update the timestamps
+expect 0 -u $UID_ROOT open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+
+
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/08.t
+++ b/tests/utimensat/08.t
@@ -1,0 +1,36 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat can set timestamps with subsecond precision"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..9"
+
+n0=`namegen`
+n1=`namegen`
+# Different file systems have different timestamp resolutions.  Check that they
+# can do 0.1 second, but don't bother checking the finest resolution.
+DATE1=100000000 #Sat Mar  3 02:46:40 MST 1973
+DATE1_NS=100000000
+DATE2=200000000 #Mon May  3 13:33:20 MDT 1976
+DATE2_NS=200000000
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+create_file regular ${n0} 0644
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 $DATE1_NS $DATE2 $DATE2_NS 0
+expect $DATE1_NS lstat ${n0} atime_ns
+expect $DATE2_NS lstat ${n0} mtime_ns
+if supported "stat_st_birthtime"; then
+	expect $DATE2_NS lstat ${n0} birthtime_ns
+else
+	test_check true
+fi
+
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}

--- a/tests/utimensat/09.t
+++ b/tests/utimensat/09.t
@@ -1,0 +1,31 @@
+#! /bin/sh
+# $FreeBSD$
+
+desc="utimensat is y2038 compliant"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+echo "1..7"
+
+require utimensat
+
+n0=`namegen`
+n1=`namegen`
+DATE1=2147483648	# 2^31, ie Mon Jan 18 20:14:08 MST 2038
+DATE2=4294967296	# 2^32, ie Sat Feb  6 23:28:16 MST 2106
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+
+create_file regular ${n0}
+expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
+expect $DATE1 lstat ${n0} atime
+expect $DATE2 lstat ${n0} mtime
+
+
+expect 0 unlink ${n0}
+
+cd ${cdir}
+expect 0 rmdir ${n1}


### PR DESCRIPTION
Add tests for utimensat(2).  They pass on FreeBSD/UFS.  They fail on FreeBSD/ZFS (but I have a fix ready).  I haven't tested them on Linux or Illumos.