### PR TITLE
pjdfstest: fix basic OSX support

### DIFF
--- a/pjdfstest.c
+++ b/pjdfstest.c
@@ -96,8 +96,10 @@
 #define	HAS_FSTATAT
 #define	HAS_LINKAT
 #define	HAS_MKDIRAT
+#ifndef	__APPLE__
 #define	HAS_MKFIFOAT
 #define	HAS_MKNODAT
+#endif
 #define	HAS_OPENAT
 #define	HAS_READLINKAT
 #define	HAS_RENAMEAT

--- a/tests/chmod/11.t
+++ b/tests/chmod/11.t
@@ -63,6 +63,12 @@ for type in regular fifo block char socket symlink; do
 		create_file ${type} ${n1} 0640 65534 65534
 		expect 0 symlink ${n1} ${n2}
 		case "${os}" in
+		Darwin)
+			expect 0 -u 65534 -g 65534 chmod ${n1} 01644
+			expect 01644 stat ${n1} mode
+			expect 0 -u 65534 -g 65534 chmod ${n2} 01640
+			expect 01640 stat ${n1} mode
+			;;
 		FreeBSD)
 			expect EFTYPE -u 65534 -g 65534 chmod ${n1} 01644
 			expect 0640 stat ${n1} mode
@@ -93,6 +99,10 @@ for type in regular fifo block char socket symlink; do
 	if supported lchmod; then
 		create_file ${type} ${n1} 0640 65534 65534
 		case "${os}" in
+		Darwin)
+			expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
+			expect 01644 lstat ${n1} mode
+			;;
 		FreeBSD)
 			expect EFTYPE -u 65534 -g 65534 lchmod ${n1} 01644
 			expect 0640 lstat ${n1} mode

--- a/tests/conf
+++ b/tests/conf
@@ -23,7 +23,13 @@ get_mountpoint()
 }
 
 case "${os}" in
-FreeBSD|Darwin)
+Darwin)
+	GREP=grep
+	#fs=`df -T . | tail -1 | awk '{print $2}'`
+	mountpoint="`get_mountpoint`"
+	fs=`mount | grep "on $mountpoint" | sed -e 's/.*(//' -e 's/,.*//g' | tr '[:lower:]' '[:upper:]'`
+	;;
+FreeBSD)
 	GREP=grep
 	#fs=`df -T . | tail -1 | awk '{print $2}'`
 	mountpoint="`get_mountpoint`"

--- a/tests/conf
+++ b/tests/conf
@@ -13,8 +13,8 @@ unsupported_os()
 get_mountpoint()
 {
 	case "${os}" in
-	FreeBSD|Darwin)
-		df . | tail -1 | awk '{print $6}'
+	Darwin|FreeBSD)
+		df . | tail -1 | awk '{print $NF}'
 		;;
 	*)
 		unsupported_os


### PR DESCRIPTION
This addresses some base issues which prevented pjdfstest from being compiled/run on OS X clients.

There are 14 failed test programs that need to be fixed on OS X still, in part due to:
- bugs within OS X that will need to be brought up with Apple
- buggy assumptions in the tests

Tested on: El Capitan (10.11.6)
Sponsored by: Dell EMC Isilon

```pinklady:~ ngie$ sudo prove -rv .
...
Test Summary Report
-------------------
./chown/00.t    (Wstat: 0 Tests: 1323 Failed: 38)
  Failed tests:  1098, 1102, 1108, 1113, 1117, 1123, 1128
                1132, 1138, 1143, 1147, 1153, 1158, 1162
                1168, 1173, 1177, 1183, 1188, 1195, 1201
                1209, 1216, 1222, 1230, 1237, 1243, 1251
                1258, 1264, 1272, 1279, 1285, 1293, 1300
                1306, 1314, 1321
./chown/07.t    (Wstat: 0 Tests: 132 Failed: 19)
  Failed tests:  7, 12, 20, 27, 32, 40, 47, 52, 60, 67, 72
                80, 87, 92, 100, 107, 112, 120, 127
./ftruncate/12.t (Wstat: 0 Tests: 3 Failed: 1)
  Failed test:  2
./link/00.t     (Wstat: 0 Tests: 202 Failed: 46)
  Failed tests:  56-67, 70-72, 74, 76, 82-93, 96-98, 100
                102, 147-150, 152, 154-157, 159, 183, 190
./mkfifo/03.t   (Wstat: 256 Tests: 4 Failed: 1)
  Failed test:  3
  Non-zero exit status: 1
./mknod/03.t    (Wstat: 256 Tests: 12 Failed: 7)
  Failed tests:  3, 5-7, 9-11
  Non-zero exit status: 1
./rename/00.t   (Wstat: 0 Tests: 150 Failed: 19)
  Failed tests:  38-40, 42, 44-45, 53-55, 57, 59-60, 96
                100, 104, 108, 112, 116, 120
./rename/09.t   (Wstat: 0 Tests: 2353 Failed: 16)
  Failed tests:  2269-2272, 2279-2281, 2284, 2289-2292, 2299-2301
                2304
./rename/10.t   (Wstat: 0 Tests: 2099 Failed: 8)
  Failed tests:  2056-2058, 2061, 2063-2065, 2068
./rename/21.t   (Wstat: 0 Tests: 16 Failed: 1)
  Failed test:  5
./symlink/03.t  (Wstat: 256 Tests: 6 Failed: 1)
  Failed test:  4
  Non-zero exit status: 1
./truncate/12.t (Wstat: 0 Tests: 3 Failed: 1)
  Failed test:  2
./unlink/00.t   (Wstat: 0 Tests: 112 Failed: 6)
  Failed tests:  37-39, 42-44
pinklady:~ ngie$ uname -a
Darwin pinklady.local 15.6.0 Darwin Kernel Version 15.6.0: Fri Feb 17 10:21:18 PST 2017; root:xnu-3248.60.11.4.1~1/RELEASE_X86_64 x86_64
```