### PR TITLE
Don't use lchmod on OSes that don't support it

### DIFF
--- a/tests/chmod/02.t
+++ b/tests/chmod/02.t
@@ -6,7 +6,11 @@ desc="chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..10"
+if supported lchmod; then
+	echo "1..10"
+else
+	echo "1..5"
+fi
 
 nx=`namegen_max`
 nxx="${nx}x"
@@ -17,8 +21,10 @@ expect 0620 stat ${nx} mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG chmod ${nxx} 0620
 
-expect 0 create ${nx} 0644
-expect 0 lchmod ${nx} 0620
-expect 0620 stat ${nx} mode
-expect 0 unlink ${nx}
-expect ENAMETOOLONG lchmod ${nxx} 0620
+if supported lchmod; then
+	expect 0 create ${nx} 0644
+	expect 0 lchmod ${nx} 0620
+	expect 0620 stat ${nx} mode
+	expect 0 unlink ${nx}
+	expect ENAMETOOLONG lchmod ${nxx} 0620
+fi

--- a/tests/chmod/03.t
+++ b/tests/chmod/03.t
@@ -6,7 +6,11 @@ desc="chmod returns ENAMETOOLONG if an entire path name exceeded {PATH_MAX} char
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..10"
+if supported lchmod; then
+	echo "1..10"
+else
+	echo "1..5"
+fi
 
 nx=`dirgen_max`
 nxx="${nx}x"
@@ -19,10 +23,12 @@ expect 0642 stat ${nx} mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG chmod ${nxx} 0642
 
-expect 0 create ${nx} 0644
-expect 0 lchmod ${nx} 0642
-expect 0642 stat ${nx} mode
-expect 0 unlink ${nx}
-expect ENAMETOOLONG lchmod ${nxx} 0642
+if supported lchmod; then
+	expect 0 create ${nx} 0644
+	expect 0 lchmod ${nx} 0642
+	expect 0642 stat ${nx} mode
+	expect 0 unlink ${nx}
+	expect ENAMETOOLONG lchmod ${nxx} 0642
+fi
 
 rm -rf "${nx%%/*}"

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -290,11 +290,19 @@ create_file() {
 		;;
 	esac
 	if [ -n "${3}" -a -n "${4}" -a -n "${5}" ]; then
-		expect 0 lchmod ${name} ${3}
+		if [ "${type}" = symlink ]; then
+			expect 0 lchmod ${name} ${3}
+		else
+			expect 0 chmod ${name} ${3}
+		fi
 		expect 0 lchown ${name} ${4} ${5}
 	elif [ -n "${3}" -a -n "${4}" ]; then
 		expect 0 lchown ${name} ${3} ${4}
 	elif [ -n "${3}" ]; then
-		expect 0 lchmod ${name} ${3}
+		if [ "${type}" = symlink ]; then
+			expect 0 lchmod ${name} ${3}
+		else
+			expect 0 chmod ${name} ${3}
+		fi
 	fi
 }


### PR DESCRIPTION
tests/chmod/02.t
tests/chmod/03.t
	Add "supported lchmod" guards.

tests/misc.sh
	Modify create_file to only use lchmod when creating a symlink.
	For other filetypes, use plain chmod.

Fixes #8