### PR TITLE
pjdfstest: fix linux support

### DIFF
--- a/tests/chown/00.t
+++ b/tests/chown/00.t
@@ -214,6 +214,20 @@ done
 # when non-super-user calls chown(2) successfully, set-uid and set-gid bits may
 # be removed, except when both uid and gid are equal to -1.
 for type in regular dir fifo block char socket symlink; do
+	#
+	# Linux makes a destinction for behavior when an executable file vs a
+	# non-executable file. From chmod(2):
+	#
+	#   When the owner or group of an executable file are changed by an
+	#   unprivileged user the S_ISUID and S_ISGID mode bits are cleared.
+	#
+	# I believe in this particular case, the behavior's bugged.
+	#
+	if [ "${type}" = "dir" -a "${os}" = "Linux" ]; then
+		_todo_msg="Linux doesn't clear the SGID/SUID bits for directories, despite the description noted"
+	else
+		_todo_msg=
+	fi
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -221,10 +235,12 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 chmod ${n0} 06555
 		expect 06555,65534,65533 stat ${n0} mode,uid,gid
 		expect 0 -u 65534 -g 65533,65532 chown ${n0} 65534 65532
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65532 stat ${n0} mode,uid,gid
 		expect 0 chmod ${n0} 06555
 		expect 06555,65534,65532 stat ${n0} mode,uid,gid
 		expect 0 -u 65534 -g 65533,65532 -- chown ${n0} -1 65533
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65533 stat ${n0} mode,uid,gid
 		expect 0 chmod ${n0} 06555
 		expect 06555,65534,65533 stat ${n0} mode,uid,gid
@@ -237,13 +253,17 @@ for type in regular dir fifo block char socket symlink; do
 		expect 06555,65534,65533 stat ${n0} mode,uid,gid
 		expect 06555,65534,65533 stat ${n1} mode,uid,gid
 		expect 0 -u 65534 -g 65533,65532 chown ${n1} 65534 65532
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65532 stat ${n0} mode,uid,gid
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65532 stat ${n1} mode,uid,gid
 		expect 0 chmod ${n1} 06555
 		expect 06555,65534,65532 stat ${n0} mode,uid,gid
 		expect 06555,65534,65532 stat ${n1} mode,uid,gid
 		expect 0 -u 65534 -g 65533,65532 -- chown ${n1} -1 65533
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65533 stat ${n0} mode,uid,gid
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65533 stat ${n1} mode,uid,gid
 		expect 0 chmod ${n1} 06555
 		expect 06555,65534,65533 stat ${n0} mode,uid,gid
@@ -271,6 +291,7 @@ for type in regular dir fifo block char socket symlink; do
 		fi
 		expect 06555,65534,65533 lstat ${n0} mode,uid,gid
 		expect 0 -u 65534 -g 65533,65532 lchown ${n0} 65534 65532
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65532 lstat ${n0} mode,uid,gid
 		if supported lchmod; then
 			expect 0 lchmod ${n0} 06555
@@ -279,6 +300,7 @@ for type in regular dir fifo block char socket symlink; do
 		fi
 		expect 06555,65534,65532 lstat ${n0} mode,uid,gid
 		expect 0 -u 65534 -g 65533,65532 -- lchown ${n0} -1 65533
+		[ -n "${_todo_msg}" ] && todo "Linux" "${_todo_msg}"
 		expect 0555,65534,65533 lstat ${n0} mode,uid,gid
 		if supported lchmod; then
 			expect 0 lchmod ${n0} 06555

--- a/tests/open/24.t
+++ b/tests/open/24.t
@@ -2,17 +2,31 @@
 # vim: filetype=sh noexpandtab ts=8 sw=8
 # $FreeBSD: head/tools/regression/pjdfstest/tests/open/24.t 211352 2010-08-15 21:24:17Z pjd $
 
-desc="open returns EOPNOTSUPP when trying to open UNIX domain socket"
-
 dir=`dirname $0`
 . ${dir}/../misc.sh
+
+# POSIX doesn't explicitly state the errno for open(2)'ing sockets.
+case ${os} in
+Darwin|FreeBSD)
+	expected_error=EOPNOTSUPP
+	;;
+Linux)
+	expected_error=ENXIO
+	;;
+*)
+	echo "1..0 # SKIP: unsupported OS: ${os}"
+	exit 0
+	;;
+esac
+
+desc="open returns $expected_error when trying to open UNIX domain socket"
 
 echo "1..5"
 
 n0=`namegen`
 
 expect 0 bind ${n0}
-expect "EOPNOTSUPP" open ${n0} O_RDONLY
-expect "EOPNOTSUPP" open ${n0} O_WRONLY
-expect "EOPNOTSUPP" open ${n0} O_RDWR
+expect $expected_error open ${n0} O_RDONLY
+expect $expected_error open ${n0} O_WRONLY
+expect $expected_error open ${n0} O_RDWR
 expect 0 unlink ${n0}


### PR DESCRIPTION
The pull request addresses two sets of failures that presently occur on Linux:

chmod/00.t: Linux exhibits buggy behavior when it comes to setting/unsetting sgid/suid bits on directories when executed as non-root users. Expect some of the sub testcases to fail on Linux (I need to follow up with the kernel.org folks over the man-pages documented behavior in chown(2)).
open/24.t: Linux fails when opening named sockets with ENXIO instead of EOPNOTSUPP. This behavior isn't listed on open group, and the test currently implemented is for BSD, so adjust the expectations to match open(2) behavior documented for Linux.

Tested with: Fedora 25, Travis-CI (Ubuntu 16.04 LTS)
Sponsored by: Dell EMC Isilon