### PR TITLE
Add necessary integration pieces for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+sudo: required
+
+matrix:
+    include:
+        - os: linux
+          compiler: clang
+          dist: xenial
+        - os: linux
+          compiler: gcc
+          dist: xenial
+
+script:
+    - ./travis/build.sh
+    - ./travis/test.sh

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+cd $(dirname $0)/..
+make

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -ex
+
+cd $(dirname $0)/..
+
+df .
+uname -a
+
+case "$(uname)" in
+Darwin)
+	sw_vers -productVersion
+	mount
+	;;
+FreeBSD)
+	mount -p
+	;;
+Linux)
+	for release_file in /etc/lsb-release /etc/os-release; do
+		echo "$release_file.. ->"
+		cat $release_file
+	done
+	mount
+	;;
+esac
+
+sudo prove -rv .


### PR DESCRIPTION
Add necessary integration pieces for Travis CI
    
- .travis.yml: provides the metadata for describing how the project should be built and tested.
- travis/build.sh: builds the project.
- travis/test.sh: tests the project.

This commit adds support for the following matrix:
- Ubuntu 16.04 LTS (xenial) x {clang,gcc} x {ext4}

Support for OS X will be added once runtime issues with it have been resolved.
    
Some administrative switches need to be flipped in order for this change to be made effective, but this has proven successful on my fork (yaneurabeya/pjdfstest).
    
Capture client information for FreeBSD, Linux, and OS X

FreeBSD isn't supported with Travis CI, but Linux definitely is, and OS X is partially supported.

Fixes GitHub issue #12.