### PR TITLE
Add [build-only] OS X Travis CI integration for clang/gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ matrix:
         - os: linux
           compiler: gcc
           dist: xenial
+        - os: osx
+          compiler: clang
+        - os: osx
+          compiler: gcc
 
 script:
     - ./travis/build.sh

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -11,6 +11,8 @@ case "$(uname)" in
 Darwin)
 	sw_vers -productVersion
 	mount
+	# FIXME: OSX has test issues that need to be addressed per Issue #13.
+	exit 0
 	;;
 FreeBSD)
 	mount -p


### PR DESCRIPTION
Add [build-only] OS X Travis CI integration for clang/gcc

Reasoning for build-only testing:
* The OS X machine pool is limited.
* There are bugs that need to be resolved with long pathnames, etc,
  which makes cleanup noisome.
* The test suite doesn't pass 100% on OS X.

See issue #13 for more details.