### PR TITLE
Fix build with glibc >= 2.28

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_CHECK_HEADERS([ \
     sys/mkdev.h \
+    sys/sysmacros.h \
 ])
 
 #HAS_FREEBSD_ACL

--- a/pjdfstest.c
+++ b/pjdfstest.c
@@ -36,6 +36,9 @@
 #ifdef	HAVE_SYS_MKDEV_H
 #include <sys/mkdev.h>
 #endif
+#ifdef HAVE_SYS_SYSMACROS_H
+#include <sys/sysmacros.h>
+#endif
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>


### PR DESCRIPTION
major/minor/makedev are defined in sys/sysmacros.h now.