### PR TITLE
WIP: update FUSE tests for FreeBSD 13

### DIFF
--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -182,7 +182,7 @@ supported()
 			return 1
 		fi
 		# Only OSXFuse supports chflags
-		if [ "${fs}" == "FUSEFS" ]; then
+		if [ "${fs%%.*}" == "FUSEFS" ]; then
 			return 1
 		fi
 		;;
@@ -197,7 +197,7 @@ supported()
 		if [ "${os}" != "FreeBSD" ]; then
 			return 1
 		fi
-		if [ "${fs}" == "FUSEFS" ]; then
+		if [ "${fs%%.*}" == "FUSEFS" ]; then
 			return 1
 		fi
 		;;
@@ -210,7 +210,7 @@ supported()
 			;;
 		esac
 		# Only OSXFuse supports st_birthtime
-		if [ "${os}" != "Darwin" -a "${fs}" == "FUSEFS" ]; then
+		if [ "${os}" != "Darwin" -a "${fs%%.*}" == "FUSEFS" ]; then
 			return 1
 		fi
 		;;
@@ -223,7 +223,7 @@ supported()
 		;;
 	UTIME_NOW)
 		# UTIME_NOW isn't supported until FUSE protocol 7.9
-		if [ "${os}" == "FreeBSD" -a "${fs}" == "FUSEFS" ]; then
+		if [ "${os}" == "FreeBSD" -a "${fs%%.*}" == "FUSEFS" ]; then
 			return 1
 		fi
 		;;

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -181,6 +181,7 @@ supported()
 		if [ "${os}" != "FreeBSD" ]; then
 			return 1
 		fi
+		# Only OSXFuse supports chflags
 		if [ "${fs}" == "FUSEFS" ]; then
 			return 1
 		fi
@@ -191,12 +192,12 @@ supported()
 		fi
 		;;
 	mknod)
-		if [ "${fs}" == "FUSEFS" ]; then
-			return 1
-		fi
 		;;
 	posix_fallocate)
 		if [ "${os}" != "FreeBSD" ]; then
+			return 1
+		fi
+		if [ "${fs}" == "FUSEFS" ]; then
 			return 1
 		fi
 		;;
@@ -208,6 +209,10 @@ supported()
 			return 1
 			;;
 		esac
+		# Only OSXFuse supports st_birthtime
+		if [ "${os}" != "Darwin" -a "${fs}" == "FUSEFS" ]; then
+			return 1
+		fi
 		;;
 	utimensat)
 		case ${os} in
@@ -215,6 +220,12 @@ supported()
 			return 1
 			;;
 		esac
+		;;
+	UTIME_NOW)
+		# UTIME_NOW isn't supported until FUSE protocol 7.9
+		if [ "${os}" == "FreeBSD" -a "${fs}" == "FUSEFS" ]; then
+			return 1
+		fi
 		;;
 	esac
 	return 0

--- a/tests/rename/09.t
+++ b/tests/rename/09.t
@@ -118,7 +118,7 @@ expect ENOENT lstat ${n0}/${n2} type
 expect ${inode},65534,65534 lstat ${n1}/${n3} inode,uid,gid
 expect 0 rmdir ${n1}/${n3}
 
-# User owns the source sticky directory, but doesn't own the source directory.
+# User owns the source sticky directory, but doesn't own the source file.
 # This fails when changing parent directory, because this will modify
 # source directory inode (the .. link in it), but we can still rename it
 # without changing its parent directory.

--- a/tests/utimensat/06.t
+++ b/tests/utimensat/06.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require "utimensat"
+require "UTIME_NOW"
 
 echo "1..13"
 


### PR DESCRIPTION
This PR updates `supported()` to reflect the state of fusefs in FreeBSD 13.  This PR should not be merged before the SVN fuse2 branch is merged to head.