### PR TITLE
open FIFO with O_NONBLOCK always

### DIFF
--- a/tests/open/06.t
+++ b/tests/open/06.t
@@ -94,51 +94,51 @@ expect 0 -u 65534 -g 65534 mkfifo ${n1} 0644
 
 expect 0 -u 65534 -g 65534 chmod ${n1} 0600
 expect 0 -u 65534 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
-expect 0 -u 65534 -g 65534 open ${n1} O_RDWR,O_NONBLOCK
+expect 0 -u 65534 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0060
 expect 0 -u 65533 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
-expect 0 -u 65533 -g 65534 open ${n1} O_RDWR,O_NONBLOCK
+expect 0 -u 65533 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0006
 expect 0 -u 65533 -g 65533 open ${n1} O_RDONLY,O_NONBLOCK
-expect 0 -u 65533 -g 65533 open ${n1} O_RDWR,O_NONBLOCK
+expect 0 -u 65533 -g 65533 open ${n1} O_RDWR
 
 expect 0 -u 65534 -g 65534 chmod ${n1} 0477
 expect 0 -u 65534 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
-expect EACCES -u 65534 -g 65534 open ${n1} O_WRONLY
+expect EACCES -u 65534 -g 65534 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65534 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0747
 expect 0 -u 65533 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
-expect EACCES -u 65533 -g 65534 open ${n1} O_WRONLY
+expect EACCES -u 65533 -g 65534 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0774
 expect 0 -u 65533 -g 65533 open ${n1} O_RDONLY,O_NONBLOCK
-expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY
+expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65533 open ${n1} O_RDWR
 
 expect 0 -u 65534 -g 65534 chmod ${n1} 0177
-expect EACCES -u 65534 -g 65534 open ${n1} O_RDONLY
-expect EACCES -u 65534 -g 65534 open ${n1} O_WRONLY
+expect EACCES -u 65534 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
+expect EACCES -u 65534 -g 65534 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65534 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0717
-expect EACCES -u 65533 -g 65534 open ${n1} O_RDONLY
-expect EACCES -u 65533 -g 65534 open ${n1} O_WRONLY
+expect EACCES -u 65533 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
+expect EACCES -u 65533 -g 65534 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0771
-expect EACCES -u 65533 -g 65533 open ${n1} O_RDONLY
-expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY
+expect EACCES -u 65533 -g 65533 open ${n1} O_RDONLY,O_NONBLOCK
+expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65533 open ${n1} O_RDWR
 
 expect 0 -u 65534 -g 65534 chmod ${n1} 0077
-expect EACCES -u 65534 -g 65534 open ${n1} O_RDONLY
-expect EACCES -u 65534 -g 65534 open ${n1} O_WRONLY
+expect EACCES -u 65534 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
+expect EACCES -u 65534 -g 65534 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65534 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0707
-expect EACCES -u 65533 -g 65534 open ${n1} O_RDONLY
-expect EACCES -u 65533 -g 65534 open ${n1} O_WRONLY
+expect EACCES -u 65533 -g 65534 open ${n1} O_RDONLY,O_NONBLOCK
+expect EACCES -u 65533 -g 65534 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65534 open ${n1} O_RDWR
 expect 0 -u 65534 -g 65534 chmod ${n1} 0770
-expect EACCES -u 65533 -g 65533 open ${n1} O_RDONLY
-expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY
+expect EACCES -u 65533 -g 65533 open ${n1} O_RDONLY,O_NONBLOCK
+expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65533 open ${n1} O_RDWR
 
 expect 0 -u 65534 -g 65534 unlink ${n1}


### PR DESCRIPTION
When open a FIFO without O_NONBLOCK, the syscall will be blocked if the it's not opened both for read and writing. So when open in read or write only, O_NONBLOCK should be used together, otherwise it could hang.

Closes #32 