### PR TITLE
Don't require a file system to update ctime on rename

### DIFF
--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -201,6 +201,26 @@ supported()
 			return 1
 		fi
 		;;
+	rename_ctime)
+		# POSIX does not require a file system to update a file's ctime
+		# when it gets renamed, but some file systems choose to do it
+		# anyway.
+		# https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html
+		case "${fs}" in
+		EXT4)
+			return 0
+			;;
+		UFS)
+			return 0
+			;;
+		ZFS)
+			return 0
+			;;
+		*)
+			return 1;
+			;;
+		esac
+		;;
 	stat_st_birthtime)
 		case "${os}" in
 		Darwin|FreeBSD)

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -7,7 +7,7 @@ desc="rename changes file name"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..150"
+echo "1..122"
 
 n0=`namegen`
 n1=`namegen`
@@ -57,21 +57,6 @@ expect ENOENT lstat ${n1} type,mode
 expect symlink,${sinode} lstat ${n2} type,inode
 expect 0 unlink ${n0}
 expect 0 unlink ${n2}
-
-# successful rename(2) updates ctime.
-for type in regular dir fifo block char socket symlink; do
-	create_file ${type} ${n0}
-	ctime1=`${fstest} lstat ${n0} ctime`
-	sleep 1
-	expect 0 rename ${n0} ${n1}
-	ctime2=`${fstest} lstat ${n1} ctime`
-	test_check $ctime1 -lt $ctime2
-	if [ "${type}" = "dir" ]; then
-		expect 0 rmdir ${n1}
-	else
-		expect 0 unlink ${n1}
-	fi
-done
 
 # unsuccessful link(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do

--- a/tests/rename/22.t
+++ b/tests/rename/22.t
@@ -1,0 +1,38 @@
+#!/bin/sh
+# vim: filetype=sh noexpandtab ts=8 sw=8
+# $FreeBSD$
+
+desc="rename changes file ctime"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+
+require rename_ctime
+
+echo "1..30"
+
+src=`namegen`
+dst=`namegen`
+parent=`namegen`
+
+expect 0 mkdir ${parent} 0755
+cdir=`pwd`
+cd ${parent}
+
+# successful rename(2) updates ctime.
+for type in regular dir fifo block char socket symlink; do
+	create_file ${type} ${src}
+	ctime1=`${fstest} lstat ${src} ctime`
+	sleep 1
+	expect 0 rename ${src} ${dst}
+	ctime2=`${fstest} lstat ${dst} ctime`
+	test_check $ctime1 -lt $ctime2
+	if [ "${type}" = "dir" ]; then
+		expect 0 rmdir ${dst}
+	else
+		expect 0 unlink ${dst}
+	fi
+done
+
+cd ${cdir}
+expect 0 rmdir ${parent}


### PR DESCRIPTION
POSIX explicitly says that a file system may or may not update ctime
during rename.  This change removes pjdfstest's expectation that it
will.

Fixes #34