### PR TITLE
Add a test for open-but-deleted files

### DIFF
--- a/pjdfstest.c
+++ b/pjdfstest.c
@@ -150,6 +150,7 @@ enum action {
 	ACTION_PREPENDACL,
 	ACTION_READACL,
 #endif
+	ACTION_PREAD,
 	ACTION_WRITE,
 #ifdef	HAVE_UTIMENSAT
 	ACTION_UTIMENSAT,
@@ -261,6 +262,7 @@ static struct syscall_desc syscalls[] = {
 	{ "prependacl", ACTION_PREPENDACL, { TYPE_STRING, TYPE_STRING, TYPE_NONE } },
 	{ "readacl", ACTION_READACL, { TYPE_STRING, TYPE_NONE } },
 #endif
+	{ "pread", ACTION_PREAD, { TYPE_DESCRIPTOR, TYPE_NUMBER, TYPE_NONE } },
 	{ "write", ACTION_WRITE, { TYPE_DESCRIPTOR, TYPE_STRING, TYPE_NONE } },
 #ifdef	HAVE_UTIMENSAT
 	{ "utimensat", ACTION_UTIMENSAT, {
@@ -1147,6 +1149,31 @@ call_syscall(struct syscall_desc *scall, char *argv[])
 			rval = 0;
 		break;
 #endif
+	case ACTION_PREAD:
+	    {
+		char buf[1024];
+		ssize_t r;
+		int fd = NUM(0);
+		off_t off = NUM(1);
+
+		rval = 0;
+		bzero(buf, sizeof(buf));
+		do {
+			r = pread(fd, buf + rval, sizeof(buf) - rval,
+			    off + rval);
+			fprintf(stderr, "read %ld bytes\n", r);
+			if (r < 0) {
+				rval = r;
+				break;
+			}
+			rval += r;
+		} while (r != 0) ;
+		if (rval >= 0) {
+			printf("%s\n", buf);
+			return (i);
+		}
+		break;
+	    }
 	case ACTION_WRITE:
 		rval = write(NUM(0), STR(1), strlen(STR(1)));
 		break;

--- a/tests/unlink/14.t
+++ b/tests/unlink/14.t
@@ -1,0 +1,33 @@
+#!/bin/sh
+# vim: filetype=sh noexpandtab ts=8 sw=8
+# $FreeBSD$
+
+desc="An open file will not be immediately freed by unlink"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+
+echo "1..7"
+
+n0=`namegen`
+n2=`namegen`
+
+expect 0 mkdir ${n2} 0755
+cdir=`pwd`
+cd ${n2}
+
+# Stating open but deleted files should work
+expect 0 create ${n0} 0644
+expect 0 open ${n0} O_WRONLY : write 0 "Hello, World!"
+# A deleted file's link count should be 0
+expect 0 open ${n0} O_RDONLY : unlink ${n0} : fstat 0 nlink
+
+# I/O to open but deleted files should work, too
+expect 0 create ${n0} 0644
+expect "Hello,_World!" open ${n0} O_RDWR : \
+	write 0 "Hello,_World!" : \
+	unlink ${n0} : \
+	pread 0 0
+
+cd ${cdir}
+expect 0 rmdir ${n2}


### PR DESCRIPTION
unlink should be able to delete a file, but processes can still use it
until last close.