### PR TITLE
Add a test for interacting with > 2 GB file

### DIFF
--- a/tests/open/25.t
+++ b/tests/open/25.t
@@ -1,0 +1,21 @@
+#!/bin/sh
+# vim: filetype=sh noexpandtab ts=8 sw=8
+
+desc="interact with > 2 GB files"
+
+dir=`dirname $0`
+. ${dir}/../misc.sh
+
+echo "1..5"
+
+n0=`namegen`
+n1=`namegen`
+
+expect 0 mkdir ${n1} 0755
+cdir=`pwd`
+cd ${n1}
+
+expect 0 open ${n0} O_CREAT,O_WRONLY 0755 : pwrite 0 "a" $((2 * 1024 * 1024 * 1024 + 1))
+expect $((2 * 1024 * 1024 * 1024 + 2)) lstat ${n0} size
+expect "a" open ${n0} O_RDONLY : pread 0 1 $((2 * 1024 * 1024 * 1024 + 1))
+expect 0 unlink ${n0}

--- a/tests/unlink/14.t
+++ b/tests/unlink/14.t
@@ -27,7 +27,7 @@ expect 0 create ${n0} 0644
 expect "Hello,_World!" open ${n0} O_RDWR : \
 	write 0 "Hello,_World!" : \
 	unlink ${n0} : \
-	pread 0 0
+	pread 0 13 0
 
 cd ${cdir}
 expect 0 rmdir ${n2}


### PR DESCRIPTION
This can catch `size_t`/`off_t` mismatches on 32-bit systems.  Also
correct `pread` to include count.