### PR TITLE
Require hard link support for hard link tests

### DIFF
--- a/tests/link/00.t
+++ b/tests/link/00.t
@@ -7,6 +7,8 @@ desc="link creates hardlinks"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..202"
 
 n0=`namegen`

--- a/tests/link/01.t
+++ b/tests/link/01.t
@@ -7,6 +7,8 @@ desc="link returns ENOTDIR if a component of either path prefix is not a directo
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..32"
 
 n0=`namegen`

--- a/tests/link/02.t
+++ b/tests/link/02.t
@@ -7,6 +7,8 @@ desc="link returns ENAMETOOLONG if a component of either pathname exceeded {NAME
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/link/03.t
+++ b/tests/link/03.t
@@ -7,6 +7,8 @@ desc="link returns ENAMETOOLONG if an entire length of either path name exceeded
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..13"
 
 n0=`namegen`

--- a/tests/link/04.t
+++ b/tests/link/04.t
@@ -7,6 +7,8 @@ desc="link returns ENOENT if a component of either path prefix does not exist"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/link/05.t
+++ b/tests/link/05.t
@@ -9,6 +9,8 @@ dir=`dirname $0`
 
 [ "${os}:${fs}" = "FreeBSD:UFS" ] || quick_exit
 
+require link
+
 echo "1..5"
 
 n0=`namegen`

--- a/tests/link/06.t
+++ b/tests/link/06.t
@@ -7,6 +7,8 @@ desc="link returns EACCES when a component of either path prefix denies search p
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..18"
 
 n0=`namegen`

--- a/tests/link/07.t
+++ b/tests/link/07.t
@@ -7,6 +7,8 @@ desc="link returns EACCES when the requested link requires writing in a director
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..17"
 
 n0=`namegen`

--- a/tests/link/08.t
+++ b/tests/link/08.t
@@ -7,6 +7,8 @@ desc="link returns ELOOP if too many symbolic links were encountered in translat
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/link/09.t
+++ b/tests/link/09.t
@@ -7,6 +7,8 @@ desc="link returns ENOENT if the source file does not exist"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..5"
 
 n0=`namegen`

--- a/tests/link/10.t
+++ b/tests/link/10.t
@@ -7,6 +7,8 @@ desc="link returns EEXIST if the destination file does exist"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..23"
 
 n0=`namegen`

--- a/tests/link/11.t
+++ b/tests/link/11.t
@@ -7,6 +7,8 @@ desc="link returns EPERM if the source file is a directory"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 n0=`namegen`
 n1=`namegen`
 n2=`namegen`

--- a/tests/link/12.t
+++ b/tests/link/12.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require chflags
+require link
 
 case "${os}:${fs}" in
 FreeBSD:ZFS)

--- a/tests/link/13.t
+++ b/tests/link/13.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require chflags
+require link
 
 case "${os}:${fs}" in
 FreeBSD:ZFS)

--- a/tests/link/14.t
+++ b/tests/link/14.t
@@ -9,6 +9,8 @@ dir=`dirname $0`
 
 [ "${os}" = "FreeBSD" ] || quick_exit
 
+require link
+
 echo "1..8"
 
 n0=`namegen`

--- a/tests/link/15.t
+++ b/tests/link/15.t
@@ -9,6 +9,8 @@ dir=`dirname $0`
 
 [ "${os}:${fs}" = "FreeBSD:UFS" ] || quick_exit
 
+require link
+
 echo "1..4"
 
 n0=`namegen`

--- a/tests/link/16.t
+++ b/tests/link/16.t
@@ -9,6 +9,8 @@ dir=`dirname $0`
 
 [ "${os}" = "FreeBSD" ] || quick_exit
 
+require link
+
 echo "1..9"
 
 n0=`namegen`

--- a/tests/link/17.t
+++ b/tests/link/17.t
@@ -7,6 +7,8 @@ desc="link returns EFAULT if one of the pathnames specified is outside the proce
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..8"
 
 n0=`namegen`

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -191,6 +191,11 @@ supported()
 			return 1
 		fi
 		;;
+	link)
+		if [ "${fs}" == "FUSE.S3FS" ]; then
+			return 1
+		fi
+		;;
 	mknod)
 		;;
 	posix_fallocate)


### PR DESCRIPTION
Some filesystems like s3fs do not support this feature.