### PR TITLE
Mark requirements

### DIFF
--- a/tests/chflags/00.t
+++ b/tests/chflags/00.t
@@ -38,6 +38,8 @@ cdir=`pwd`
 cd ${n2}
 
 for type in regular dir fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect none stat ${n0} flags
 	expect 0 chflags ${n0} ${allflags}
@@ -69,6 +71,8 @@ for type in regular dir fifo block char socket; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 expect 0 create ${n0} 0644
@@ -111,6 +115,8 @@ expect 0 unlink ${n0}
 
 # successful chflags(2) updates ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		for flag in `echo ${allflags},none | tr ',' ' '`; do
@@ -140,10 +146,14 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 # unsuccessful chflags(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		for flag in `echo ${allflags},none | tr ',' ' '`; do
@@ -173,6 +183,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chflags/00.t
+++ b/tests/chflags/00.t
@@ -115,7 +115,7 @@ for type in regular dir fifo block char socket symlink; do
 		create_file ${type} ${n0}
 		for flag in `echo ${allflags},none | tr ',' ' '`; do
 			ctime1=`${fstest} stat ${n0} ctime`
-			sleep 1
+			nap
 			expect 0 chflags ${n0} ${flag}
 			ctime2=`${fstest} stat ${n0} ctime`
 			test_check $ctime1 -lt $ctime2
@@ -130,7 +130,7 @@ for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
 	for flag in `echo ${allflags},none | tr ',' ' '`; do
 		ctime1=`${fstest} lstat ${n0} ctime`
-		sleep 1
+		nap
 		expect 0 lchflags ${n0} ${flag}
 		ctime2=`${fstest} lstat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
@@ -148,7 +148,7 @@ for type in regular dir fifo block char socket symlink; do
 		create_file ${type} ${n0}
 		for flag in `echo ${allflags},none | tr ',' ' '`; do
 			ctime1=`${fstest} stat ${n0} ctime`
-			sleep 1
+			nap
 			expect EPERM -u 65534 chflags ${n0} ${flag}
 			ctime2=`${fstest} stat ${n0} ctime`
 			test_check $ctime1 -eq $ctime2
@@ -163,7 +163,7 @@ for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
 	for flag in `echo ${allflags},none | tr ',' ' '`; do
 		ctime1=`${fstest} lstat ${n0} ctime`
-		sleep 1
+		nap
 		expect EPERM -u 65534 lchflags ${n0} ${flag}
 		ctime2=`${fstest} lstat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2

--- a/tests/chflags/00.t
+++ b/tests/chflags/00.t
@@ -9,25 +9,24 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
-	allflags="UF_NODUMP,UF_IMMUTABLE,UF_APPEND,UF_NOUNLINK,UF_OPAQUE,SF_ARCHIVED,SF_IMMUTABLE,SF_APPEND,SF_NOUNLINK"
-	userflags="UF_NODUMP,UF_IMMUTABLE,UF_APPEND,UF_NOUNLINK,UF_OPAQUE"
-	systemflags="SF_ARCHIVED,SF_IMMUTABLE,SF_APPEND,SF_NOUNLINK"
+echo "1..742"
 
-	echo "1..742"
-	;;
-FreeBSD:ZFS)
-	allflags="UF_NODUMP,SF_IMMUTABLE,SF_APPEND,SF_NOUNLINK"
-	userflags="UF_NODUMP"
-	systemflags="SF_IMMUTABLE,SF_APPEND,SF_NOUNLINK"
+userflags="UF_NODUMP"
+for flag in UF_IMMUTABLE UF_APPEND UF_NOUNLINK UF_OPAQUE; do
+	if supported chflags_${flag}; then
+		userflags="${userflags},${flag}"
+	fi
+done
 
-	echo "1..482"
-	;;
-*)
-	quick_exit
-	;;
-esac
+systemflags="SF_IMMUTABLE,SF_APPEND,SF_NOUNLINK"
+for flag in SF_ARCHIVED; do
+	if supported chflags_${flag}; then
+		systemflags="${systemflags},${flag}"
+	fi
+done
+
+sysuserflags="${userflags},${systemflags}"
+allflags="UF_NODUMP UF_IMMUTABLE UF_APPEND UF_NOUNLINK UF_OPAQUE SF_ARCHIVED SF_IMMUTABLE SF_APPEND SF_NOUNLINK none"
 
 n0=`namegen`
 n1=`namegen`
@@ -42,8 +41,8 @@ for type in regular dir fifo block char socket; do
 
 	create_file ${type} ${n0}
 	expect none stat ${n0} flags
-	expect 0 chflags ${n0} ${allflags}
-	expect ${allflags} stat ${n0} flags
+	expect 0 chflags ${n0} ${sysuserflags}
+	expect ${sysuserflags} stat ${n0} flags
 	expect 0 chflags ${n0} ${userflags}
 	expect ${userflags} stat ${n0} flags
 	expect 0 chflags ${n0} ${systemflags}
@@ -58,8 +57,8 @@ for type in regular dir fifo block char socket; do
 
 	create_file ${type} ${n0}
 	expect none stat ${n0} flags
-	expect 0 lchflags ${n0} ${allflags}
-	expect ${allflags} stat ${n0} flags
+	expect 0 lchflags ${n0} ${sysuserflags}
+	expect ${sysuserflags} stat ${n0} flags
 	expect 0 lchflags ${n0} ${userflags}
 	expect ${userflags} stat ${n0} flags
 	expect 0 lchflags ${n0} ${systemflags}
@@ -79,8 +78,8 @@ expect 0 create ${n0} 0644
 expect 0 symlink ${n0} ${n1}
 expect none stat ${n1} flags
 expect none lstat ${n1} flags
-expect 0 chflags ${n1} ${allflags}
-expect ${allflags} stat ${n1} flags
+expect 0 chflags ${n1} ${sysuserflags}
+expect ${sysuserflags} stat ${n1} flags
 expect none lstat ${n1} flags
 expect 0 chflags ${n1} ${userflags}
 expect ${userflags} stat ${n1} flags
@@ -98,8 +97,8 @@ expect 0 create ${n0} 0644
 expect 0 symlink ${n0} ${n1}
 expect none stat ${n1} flags
 expect none lstat ${n1} flags
-expect 0 lchflags ${n1} ${allflags}
-expect ${allflags} lstat ${n1} flags
+expect 0 lchflags ${n1} ${sysuserflags}
+expect ${sysuserflags} lstat ${n1} flags
 expect none stat ${n1} flags
 expect 0 lchflags ${n1} ${userflags}
 expect ${userflags} lstat ${n1} flags
@@ -119,12 +118,14 @@ for type in regular dir fifo block char socket symlink; do
 
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
-		for flag in `echo ${allflags},none | tr ',' ' '`; do
+		for flag in ${allflags}; do
+			push_requirement chflags_${flag}
 			ctime1=`query stat ${n0} ctime`
 			nap
 			expect 0 chflags ${n0} ${flag}
 			ctime2=`query stat ${n0} ctime`
 			test_check $ctime1 -lt $ctime2
+			pop_requirement
 		done
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -134,12 +135,14 @@ for type in regular dir fifo block char socket symlink; do
 	fi
 
 	create_file ${type} ${n0}
-	for flag in `echo ${allflags},none | tr ',' ' '`; do
+	for flag in ${allflags}; do
+		push_requirement chflags_${flag}
 		ctime1=`query lstat ${n0} ctime`
 		nap
 		expect 0 lchflags ${n0} ${flag}
 		ctime2=`query lstat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
+		pop_requirement
 	done
 	if [ "${type}" = "dir" ]; then
 		expect 0 rmdir ${n0}
@@ -156,12 +159,14 @@ for type in regular dir fifo block char socket symlink; do
 
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
-		for flag in `echo ${allflags},none | tr ',' ' '`; do
+		for flag in ${allflags}; do
+			push_requirement chflags_${flag}
 			ctime1=`query stat ${n0} ctime`
 			nap
 			expect EPERM -u 65534 chflags ${n0} ${flag}
 			ctime2=`query stat ${n0} ctime`
 			test_check $ctime1 -eq $ctime2
+			pop_requirement
 		done
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -171,12 +176,14 @@ for type in regular dir fifo block char socket symlink; do
 	fi
 
 	create_file ${type} ${n0}
-	for flag in `echo ${allflags},none | tr ',' ' '`; do
+	for flag in ${allflags}; do
+		push_requirement chflags_${flag}
 		ctime1=`query lstat ${n0} ctime`
 		nap
 		expect EPERM -u 65534 lchflags ${n0} ${flag}
 		ctime2=`query lstat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2
+		pop_requirement
 	done
 	if [ "${type}" = "dir" ]; then
 		expect 0 rmdir ${n0}

--- a/tests/chflags/00.t
+++ b/tests/chflags/00.t
@@ -114,10 +114,10 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		for flag in `echo ${allflags},none | tr ',' ' '`; do
-			ctime1=`${fstest} stat ${n0} ctime`
+			ctime1=`query stat ${n0} ctime`
 			nap
 			expect 0 chflags ${n0} ${flag}
-			ctime2=`${fstest} stat ${n0} ctime`
+			ctime2=`query stat ${n0} ctime`
 			test_check $ctime1 -lt $ctime2
 		done
 		if [ "${type}" = "dir" ]; then
@@ -129,10 +129,10 @@ for type in regular dir fifo block char socket symlink; do
 
 	create_file ${type} ${n0}
 	for flag in `echo ${allflags},none | tr ',' ' '`; do
-		ctime1=`${fstest} lstat ${n0} ctime`
+		ctime1=`query lstat ${n0} ctime`
 		nap
 		expect 0 lchflags ${n0} ${flag}
-		ctime2=`${fstest} lstat ${n0} ctime`
+		ctime2=`query lstat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
 	done
 	if [ "${type}" = "dir" ]; then
@@ -147,10 +147,10 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		for flag in `echo ${allflags},none | tr ',' ' '`; do
-			ctime1=`${fstest} stat ${n0} ctime`
+			ctime1=`query stat ${n0} ctime`
 			nap
 			expect EPERM -u 65534 chflags ${n0} ${flag}
-			ctime2=`${fstest} stat ${n0} ctime`
+			ctime2=`query stat ${n0} ctime`
 			test_check $ctime1 -eq $ctime2
 		done
 		if [ "${type}" = "dir" ]; then
@@ -162,10 +162,10 @@ for type in regular dir fifo block char socket symlink; do
 
 	create_file ${type} ${n0}
 	for flag in `echo ${allflags},none | tr ',' ' '`; do
-		ctime1=`${fstest} lstat ${n0} ctime`
+		ctime1=`query lstat ${n0} ctime`
 		nap
 		expect EPERM -u 65534 lchflags ${n0} ${flag}
-		ctime2=`${fstest} lstat ${n0} ctime`
+		ctime2=`query lstat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2
 	done
 	if [ "${type}" = "dir" ]; then

--- a/tests/chflags/01.t
+++ b/tests/chflags/01.t
@@ -17,8 +17,12 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR chflags ${n0}/${n1}/test SF_IMMUTABLE
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/chflags/01.t
+++ b/tests/chflags/01.t
@@ -8,8 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require chflags
-if requires_root
-then
+require root
 
 echo "1..17"
 
@@ -23,7 +22,3 @@ for type in regular fifo block char socket; do
 	expect 0 unlink ${n0}/${n1}
 done
 expect 0 rmdir ${n0}
-
-else
-echo "1..1"
-fi

--- a/tests/chflags/07.t
+++ b/tests/chflags/07.t
@@ -20,6 +20,8 @@ cdir=`pwd`
 cd ${n0}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}
 		expect EPERM -u 65534 -g 65534 chflags ${n1} UF_NODUMP
@@ -45,6 +47,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chflags/08.t
+++ b/tests/chflags/08.t
@@ -20,6 +20,8 @@ cdir=`pwd`
 cd ${n0}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}
 		expect 0 chown ${n1} 65534 65534
@@ -53,6 +55,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chflags/09.t
+++ b/tests/chflags/09.t
@@ -23,6 +23,8 @@ cdir=`pwd`
 cd ${n0}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}
 		expect 0 chown ${n1} 65534 65534
@@ -60,6 +62,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 sysctl security.jail.chflags_allowed=${old} >/dev/null

--- a/tests/chflags/10.t
+++ b/tests/chflags/10.t
@@ -20,6 +20,8 @@ cdir=`pwd`
 cd ${n0}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}
 		expect 0 chown ${n1} 65534 65534
@@ -49,6 +51,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chflags/11.t
+++ b/tests/chflags/11.t
@@ -20,6 +20,8 @@ cdir=`pwd`
 cd ${n0}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}
 		expect EPERM -u 65534 -g 65534 chflags ${n1} SF_SNAPSHOT
@@ -53,6 +55,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chmod/00.t
+++ b/tests/chmod/00.t
@@ -22,6 +22,8 @@ cdir=`pwd`
 cd ${n2}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		expect 0 chmod ${n0} 0111
@@ -52,10 +54,14 @@ for type in regular dir fifo block char socket symlink; do
 			expect 0 unlink ${n0}
 		fi
 	fi
+
+	pop_requirement
 done
 
 # successful chmod(2) updates ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		ctime1=`query stat ${n0} ctime`
@@ -83,10 +89,14 @@ for type in regular dir fifo block char socket symlink; do
 			expect 0 unlink ${n0}
 		fi
 	fi
+
+	pop_requirement
 done
 
 # unsuccessful chmod(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		ctime1=`query stat ${n0} ctime`
@@ -114,6 +124,8 @@ for type in regular dir fifo block char socket symlink; do
 			expect 0 unlink ${n0}
 		fi
 	fi
+
+	pop_requirement
 done
 
 # POSIX: If the calling process does not have appropriate privileges, and if

--- a/tests/chmod/00.t
+++ b/tests/chmod/00.t
@@ -29,6 +29,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 chmod ${n0} 0111
 		expect 0111 stat ${n0} mode
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		mode=`query lstat ${n1} mode`
 		expect 0 chmod ${n1} 0222
@@ -36,6 +37,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0222 stat ${n0} mode
 		expect ${mode} lstat ${n1} mode
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}

--- a/tests/chmod/00.t
+++ b/tests/chmod/00.t
@@ -28,7 +28,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0111 stat ${n0} mode
 
 		expect 0 symlink ${n0} ${n1}
-		mode=`${fstest} lstat ${n1} mode`
+		mode=`query lstat ${n1} mode`
 		expect 0 chmod ${n1} 0222
 		expect 0222 stat ${n1} mode
 		expect 0222 stat ${n0} mode
@@ -58,10 +58,10 @@ done
 for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
-		ctime1=`${fstest} stat ${n0} ctime`
+		ctime1=`query stat ${n0} ctime`
 		nap
 		expect 0 chmod ${n0} 0111
-		ctime2=`${fstest} stat ${n0} ctime`
+		ctime2=`query stat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -72,10 +72,10 @@ for type in regular dir fifo block char socket symlink; do
 
 	if supported lchmod; then
 		create_file ${type} ${n0}
-		ctime1=`${fstest} lstat ${n0} ctime`
+		ctime1=`query lstat ${n0} ctime`
 		nap
 		expect 0 lchmod ${n0} 0111
-		ctime2=`${fstest} lstat ${n0} ctime`
+		ctime2=`query lstat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -89,10 +89,10 @@ done
 for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
-		ctime1=`${fstest} stat ${n0} ctime`
+		ctime1=`query stat ${n0} ctime`
 		nap
 		expect EPERM -u 65534 chmod ${n0} 0111
-		ctime2=`${fstest} stat ${n0} ctime`
+		ctime2=`query stat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -103,10 +103,10 @@ for type in regular dir fifo block char socket symlink; do
 
 	if supported lchmod; then
 		create_file ${type} ${n0}
-		ctime1=`${fstest} lstat ${n0} ctime`
+		ctime1=`query lstat ${n0} ctime`
 		nap
 		expect EPERM -u 65534 lchmod ${n0} 0321
-		ctime2=`${fstest} lstat ${n0} ctime`
+		ctime2=`query lstat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}

--- a/tests/chmod/00.t
+++ b/tests/chmod/00.t
@@ -96,6 +96,7 @@ for type in regular dir fifo block char socket symlink; do
 done
 
 # unsuccessful chmod(2) does not update ctime.
+push_requirement root
 for type in regular dir fifo block char socket symlink; do
 	push_requirement ftype_${type}
 
@@ -129,6 +130,7 @@ for type in regular dir fifo block char socket symlink; do
 
 	pop_requirement
 done
+pop_requirement
 
 # POSIX: If the calling process does not have appropriate privileges, and if
 # the group ID of the file does not match the effective group ID or one of the
@@ -136,6 +138,7 @@ done
 # (set-group-ID on execution) in the file's mode shall be cleared upon
 # successful return from chmod().
 
+push_requirement root
 expect 0 create ${n0} 0755
 expect 0 chown ${n0} 65535 65535
 expect 0 -u 65535 -g 65535 chmod ${n0} 02755
@@ -148,6 +151,7 @@ expect 0 -u 65535 -g 65534 chmod ${n0} 02755
 expect 0755 stat ${n0} mode
 
 expect 0 unlink ${n0}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n2}

--- a/tests/chmod/00.t
+++ b/tests/chmod/00.t
@@ -59,7 +59,7 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		ctime1=`${fstest} stat ${n0} ctime`
-		sleep 1
+		nap
 		expect 0 chmod ${n0} 0111
 		ctime2=`${fstest} stat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
@@ -73,7 +73,7 @@ for type in regular dir fifo block char socket symlink; do
 	if supported lchmod; then
 		create_file ${type} ${n0}
 		ctime1=`${fstest} lstat ${n0} ctime`
-		sleep 1
+		nap
 		expect 0 lchmod ${n0} 0111
 		ctime2=`${fstest} lstat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
@@ -90,7 +90,7 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		ctime1=`${fstest} stat ${n0} ctime`
-		sleep 1
+		nap
 		expect EPERM -u 65534 chmod ${n0} 0111
 		ctime2=`${fstest} stat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2
@@ -104,7 +104,7 @@ for type in regular dir fifo block char socket symlink; do
 	if supported lchmod; then
 		create_file ${type} ${n0}
 		ctime1=`${fstest} lstat ${n0} ctime`
-		sleep 1
+		nap
 		expect EPERM -u 65534 lchmod ${n0} 0321
 		ctime2=`${fstest} lstat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2

--- a/tests/chmod/01.t
+++ b/tests/chmod/01.t
@@ -14,8 +14,12 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR chmod ${n0}/${n1}/test 0644
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/chmod/02.t
+++ b/tests/chmod/02.t
@@ -7,11 +7,7 @@ desc="chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..10"
-else
-	echo "1..5"
-fi
+echo "1..10"
 
 nx=`namegen_max`
 nxx="${nx}x"
@@ -22,10 +18,10 @@ expect 0620 stat ${nx} mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG chmod ${nxx} 0620
 
-if supported lchmod; then
-	expect 0 create ${nx} 0644
-	expect 0 lchmod ${nx} 0620
-	expect 0620 stat ${nx} mode
-	expect 0 unlink ${nx}
-	expect ENAMETOOLONG lchmod ${nxx} 0620
-fi
+push_requirement lchmod
+expect 0 create ${nx} 0644
+expect 0 lchmod ${nx} 0620
+expect 0620 stat ${nx} mode
+expect 0 unlink ${nx}
+expect ENAMETOOLONG lchmod ${nxx} 0620
+pop_requirement

--- a/tests/chmod/03.t
+++ b/tests/chmod/03.t
@@ -7,11 +7,7 @@ desc="chmod returns ENAMETOOLONG if an entire path name exceeded {PATH_MAX} char
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..10"
-else
-	echo "1..5"
-fi
+echo "1..10"
 
 nx=`dirgen_max`
 nxx="${nx}x"
@@ -24,12 +20,12 @@ expect 0642 stat ${nx} mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG chmod ${nxx} 0642
 
-if supported lchmod; then
-	expect 0 create ${nx} 0644
-	expect 0 lchmod ${nx} 0642
-	expect 0642 stat ${nx} mode
-	expect 0 unlink ${nx}
-	expect ENAMETOOLONG lchmod ${nxx} 0642
-fi
+push_requirement lchmod
+expect 0 create ${nx} 0644
+expect 0 lchmod ${nx} 0642
+expect 0642 stat ${nx} mode
+expect 0 unlink ${nx}
+expect ENAMETOOLONG lchmod ${nxx} 0642
+pop_requirement
 
 rm -rf "${nx%%/*}"

--- a/tests/chmod/04.t
+++ b/tests/chmod/04.t
@@ -22,7 +22,10 @@ expect ENOENT lchmod ${n0}/${n1}/test 0644
 expect ENOENT lchmod ${n0}/${n1} 0644
 pop_requirement
 
+push_requirement ftype_symlink
 expect 0 symlink ${n2} ${n0}/${n1}
 expect ENOENT chmod ${n0}/${n1} 0644
 expect 0 unlink ${n0}/${n1}
+pop_requirement
+
 expect 0 rmdir ${n0}

--- a/tests/chmod/04.t
+++ b/tests/chmod/04.t
@@ -7,11 +7,7 @@ desc="chmod returns ENOENT if the named file does not exist"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..9"
-else
-	echo "1..7"
-fi
+echo "1..9"
 
 n0=`namegen`
 n1=`namegen`
@@ -20,10 +16,12 @@ n2=`namegen`
 expect 0 mkdir ${n0} 0755
 expect ENOENT chmod ${n0}/${n1}/test 0644
 expect ENOENT chmod ${n0}/${n1} 0644
-if supported lchmod; then
-	expect ENOENT lchmod ${n0}/${n1}/test 0644
-	expect ENOENT lchmod ${n0}/${n1} 0644
-fi
+
+push_requirement lchmod
+expect ENOENT lchmod ${n0}/${n1}/test 0644
+expect ENOENT lchmod ${n0}/${n1} 0644
+pop_requirement
+
 expect 0 symlink ${n2} ${n0}/${n1}
 expect ENOENT chmod ${n0}/${n1} 0644
 expect 0 unlink ${n0}/${n1}

--- a/tests/chmod/05.t
+++ b/tests/chmod/05.t
@@ -7,11 +7,7 @@ desc="chmod returns EACCES when search permission is denied for a component of t
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..19"
-else
-	echo "1..14"
-fi
+echo "1..19"
 
 n0=`namegen`
 n1=`namegen`
@@ -30,13 +26,15 @@ expect EACCES -u 65534 -g 65534 chmod ${n1}/${n2} 0620
 expect 0 chmod ${n1} 0755
 expect 0 -u 65534 -g 65534 chmod ${n1}/${n2} 0420
 expect 0420 -u 65534 -g 65534 stat ${n1}/${n2} mode
-if supported lchmod; then
-	expect 0 chmod ${n1} 0644
-	expect EACCES -u 65534 -g 65534 lchmod ${n1}/${n2} 0410
-	expect 0 chmod ${n1} 0755
-	expect 0 -u 65534 -g 65534 lchmod ${n1}/${n2} 0710
-	expect 0710 -u 65534 -g 65534 stat ${n1}/${n2} mode
-fi
+
+push_requirement lchmod
+expect 0 chmod ${n1} 0644
+expect EACCES -u 65534 -g 65534 lchmod ${n1}/${n2} 0410
+expect 0 chmod ${n1} 0755
+expect 0 -u 65534 -g 65534 lchmod ${n1}/${n2} 0710
+expect 0710 -u 65534 -g 65534 stat ${n1}/${n2} mode
+pop_requirement
+
 expect 0 -u 65534 -g 65534 unlink ${n1}/${n2}
 expect 0 rmdir ${n1}
 cd ${cdir}

--- a/tests/chmod/05.t
+++ b/tests/chmod/05.t
@@ -7,6 +7,8 @@ desc="chmod returns EACCES when search permission is denied for a component of t
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..19"
 
 n0=`namegen`

--- a/tests/chmod/06.t
+++ b/tests/chmod/06.t
@@ -7,6 +7,8 @@ desc="chmod returns ELOOP if too many symbolic links were encountered in transla
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/chmod/06.t
+++ b/tests/chmod/06.t
@@ -7,11 +7,7 @@ desc="chmod returns ELOOP if too many symbolic links were encountered in transla
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..10"
-else
-	echo "1..8"
-fi
+echo "1..10"
 
 n0=`namegen`
 n1=`namegen`
@@ -22,9 +18,11 @@ expect ELOOP chmod ${n0} 0644
 expect ELOOP chmod ${n1} 0644
 expect ELOOP chmod ${n0}/test 0644
 expect ELOOP chmod ${n1}/test 0644
-if supported lchmod; then
-	expect ELOOP lchmod ${n0}/test 0644
-	expect ELOOP lchmod ${n1}/test 0644
-fi
+
+push_requirement lchmod
+expect ELOOP lchmod ${n0}/test 0644
+expect ELOOP lchmod ${n1}/test 0644
+pop_requirement
+
 expect 0 unlink ${n0}
 expect 0 unlink ${n1}

--- a/tests/chmod/07.t
+++ b/tests/chmod/07.t
@@ -30,6 +30,7 @@ expect EPERM -u 65534 -g 65534 chmod ${n1}/${n2} 0641
 expect 0642 stat ${n1}/${n2} mode
 expect 0 unlink ${n1}/${n2}
 
+push_requirement ftype_symlink
 expect 0 -u 65534 -g 65534 create ${n1}/${n2} 0644
 expect 0 -u 65534 -g 65534 symlink ${n2} ${n1}/${n3}
 expect 0 -u 65534 -g 65534 chmod ${n1}/${n3} 0642
@@ -41,6 +42,7 @@ expect EPERM -u 65534 -g 65534 chmod ${n1}/${n3} 0641
 expect 0642,0,0 stat ${n1}/${n2} mode,uid,gid
 expect 0 unlink ${n1}/${n2}
 expect 0 unlink ${n1}/${n3}
+pop_requirement
 
 push_requirement lchmod
 expect 0 -u 65534 -g 65534 create ${n1}/${n2} 0644

--- a/tests/chmod/07.t
+++ b/tests/chmod/07.t
@@ -7,6 +7,8 @@ desc="chmod returns EPERM if the operation would change the ownership, but the e
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..34"
 
 n0=`namegen`

--- a/tests/chmod/07.t
+++ b/tests/chmod/07.t
@@ -7,11 +7,7 @@ desc="chmod returns EPERM if the operation would change the ownership, but the e
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..34"
-else
-	echo "1..25"
-fi
+echo "1..34"
 
 n0=`namegen`
 n1=`namegen`
@@ -46,17 +42,17 @@ expect 0642,0,0 stat ${n1}/${n2} mode,uid,gid
 expect 0 unlink ${n1}/${n2}
 expect 0 unlink ${n1}/${n3}
 
-if supported lchmod; then
-	expect 0 -u 65534 -g 65534 create ${n1}/${n2} 0644
-	expect 0 -u 65534 -g 65534 lchmod ${n1}/${n2} 0642
-	expect 0642 stat ${n1}/${n2} mode
-	expect EPERM -u 65533 -g 65533 lchmod ${n1}/${n2} 0641
-	expect 0642 stat ${n1}/${n2} mode
-	expect 0 chown ${n1}/${n2} 0 0
-	expect EPERM -u 65534 -g 65534 lchmod ${n1}/${n2} 0641
-	expect 0642 stat ${n1}/${n2} mode
-	expect 0 unlink ${n1}/${n2}
-fi
+push_requirement lchmod
+expect 0 -u 65534 -g 65534 create ${n1}/${n2} 0644
+expect 0 -u 65534 -g 65534 lchmod ${n1}/${n2} 0642
+expect 0642 stat ${n1}/${n2} mode
+expect EPERM -u 65533 -g 65533 lchmod ${n1}/${n2} 0641
+expect 0642 stat ${n1}/${n2} mode
+expect 0 chown ${n1}/${n2} 0 0
+expect EPERM -u 65534 -g 65534 lchmod ${n1}/${n2} 0641
+expect 0642 stat ${n1}/${n2} mode
+expect 0 unlink ${n1}/${n2}
+pop_requirement
 
 expect 0 rmdir ${n1}
 cd ${cdir}

--- a/tests/chmod/10.t
+++ b/tests/chmod/10.t
@@ -7,15 +7,12 @@ desc="chmod returns EFAULT if the path argument points outside the process's all
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..4"
-else
-	echo "1..2"
-fi
+echo "1..4"
 
 expect EFAULT chmod NULL 0644
 expect EFAULT chmod DEADCODE 0644
-if supported lchmod; then
-	expect EFAULT lchmod NULL 0644
-	expect EFAULT lchmod DEADCODE 0644
-fi
+
+push_requirement lchmod
+expect EFAULT lchmod NULL 0644
+expect EFAULT lchmod DEADCODE 0644
+pop_requirement

--- a/tests/chmod/11.t
+++ b/tests/chmod/11.t
@@ -18,6 +18,8 @@ cdir=`pwd`
 cd ${n0}
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}
 		expect 0 chmod ${n1} 01621
@@ -43,6 +45,8 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 unlink ${n1}
 	fi
 	pop_requirement
+
+	pop_requirement
 done
 
 expect 0 mkdir ${n1} 0755
@@ -56,6 +60,8 @@ expect 0 unlink ${n2}
 expect 0 rmdir ${n1}
 
 for type in regular fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1} 0640 65534 65534
 		expect 0 symlink ${n1} ${n2}
@@ -118,6 +124,8 @@ for type in regular fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+	pop_requirement
+
 	pop_requirement
 done
 

--- a/tests/chmod/11.t
+++ b/tests/chmod/11.t
@@ -7,11 +7,7 @@ desc="chmod returns EFTYPE if the effective user ID is not the super-user, the m
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-if supported lchmod; then
-	echo "1..173"
-else
-	echo "1..109"
-fi
+echo "1..173"
 
 n0=`namegen`
 n1=`namegen`
@@ -37,16 +33,16 @@ for type in regular dir fifo block char socket symlink; do
 		fi
 	fi
 
-	if supported lchmod; then
-		create_file ${type} ${n1}
-		expect 0 lchmod ${n1} 01621
-		expect 01621 lstat ${n1} mode
-		if [ "${type}" = "dir" ]; then
-			expect 0 rmdir ${n1}
-		else
-			expect 0 unlink ${n1}
-		fi
+	push_requirement lchmod
+	create_file ${type} ${n1}
+	expect 0 lchmod ${n1} 01621
+	expect 01621 lstat ${n1} mode
+	if [ "${type}" = "dir" ]; then
+		expect 0 rmdir ${n1}
+	else
+		expect 0 unlink ${n1}
 	fi
+	pop_requirement
 done
 
 expect 0 mkdir ${n1} 0755
@@ -97,32 +93,32 @@ for type in regular fifo block char socket symlink; do
 		fi
 	fi
 
-	if supported lchmod; then
-		create_file ${type} ${n1} 0640 65534 65534
-		case "${os}" in
-		Darwin)
-			expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
-			expect 01644 lstat ${n1} mode
-			;;
-		FreeBSD)
-			expect EFTYPE -u 65534 -g 65534 lchmod ${n1} 01644
-			expect 0640 lstat ${n1} mode
-			;;
-		SunOS)
-			expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
-			expect 0644 lstat ${n1} mode
-			;;
-		Linux)
-			expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
-			expect 01644 lstat ${n1} mode
-			;;
-		esac
-		if [ "${type}" = "dir" ]; then
-			expect 0 rmdir ${n1}
-		else
-			expect 0 unlink ${n1}
-		fi
+	push_requirement lchmod
+	create_file ${type} ${n1} 0640 65534 65534
+	case "${os}" in
+	Darwin)
+		expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
+		expect 01644 lstat ${n1} mode
+		;;
+	FreeBSD)
+		expect EFTYPE -u 65534 -g 65534 lchmod ${n1} 01644
+		expect 0640 lstat ${n1} mode
+		;;
+	SunOS)
+		expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
+		expect 0644 lstat ${n1} mode
+		;;
+	Linux)
+		expect 0 -u 65534 -g 65534 lchmod ${n1} 01644
+		expect 01644 lstat ${n1} mode
+		;;
+	esac
+	if [ "${type}" = "dir" ]; then
+		expect 0 rmdir ${n1}
+	else
+		expect 0 unlink ${n1}
 	fi
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chmod/11.t
+++ b/tests/chmod/11.t
@@ -51,6 +51,8 @@ for type in regular dir fifo block char socket symlink; do
 	pop_requirement
 done
 
+push_requirement root
+
 push_requirement ftype_symlink
 expect 0 mkdir ${n1} 0755
 expect 0 chown ${n1} 65534 65534
@@ -134,6 +136,8 @@ for type in regular fifo block char socket symlink; do
 
 	pop_requirement
 done
+
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n0}

--- a/tests/chmod/11.t
+++ b/tests/chmod/11.t
@@ -24,10 +24,12 @@ for type in regular dir fifo block char socket symlink; do
 		create_file ${type} ${n1}
 		expect 0 chmod ${n1} 01621
 		expect 01621 stat ${n1} mode
+		push_requirement ftype_symlink
 		expect 0 symlink ${n1} ${n2}
 		expect 0 chmod ${n2} 01700
 		expect 01700 stat ${n1} mode
 		expect 0 unlink ${n2}
+		pop_requirement
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n1}
 		else
@@ -49,6 +51,7 @@ for type in regular dir fifo block char socket symlink; do
 	pop_requirement
 done
 
+push_requirement ftype_symlink
 expect 0 mkdir ${n1} 0755
 expect 0 chown ${n1} 65534 65534
 expect 0 -u 65534 -g 65534 chmod ${n1} 01755
@@ -58,11 +61,13 @@ expect 0 chmod ${n2} 01700
 expect 01700 stat ${n1} mode
 expect 0 unlink ${n2}
 expect 0 rmdir ${n1}
+pop_requirement
 
 for type in regular fifo block char socket symlink; do
 	push_requirement ftype_${type}
 
 	if [ "${type}" != "symlink" ]; then
+		push_requirement ftype_symlink
 		create_file ${type} ${n1} 0640 65534 65534
 		expect 0 symlink ${n1} ${n2}
 		case "${os}" in
@@ -97,6 +102,7 @@ for type in regular fifo block char socket symlink; do
 		else
 			expect 0 unlink ${n1}
 		fi
+		pop_requirement
 	fi
 
 	push_requirement lchmod

--- a/tests/chmod/12.t
+++ b/tests/chmod/12.t
@@ -7,6 +7,8 @@ desc="verify SUID/SGID bit behaviour"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..14"
 
 n0=`namegen`

--- a/tests/chown/00.t
+++ b/tests/chown/00.t
@@ -33,6 +33,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 chown ${n0} 0 0
 		expect 0,0 lstat ${n0} uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		uidgid=`query lstat ${n1} uid,gid`
 		expect 0 chown ${n1} 123 456
@@ -40,6 +41,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 123,456 stat ${n0} uid,gid
 		expect ${uidgid} lstat ${n1} uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -75,6 +77,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 -u 65534 -g 65532,65531 chown ${n0} 65534 65531
 		expect 65534,65531 lstat ${n0} uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		uidgid=`query lstat ${n1} uid,gid`
 		expect 0 chown ${n1} 65534 65533
@@ -90,6 +93,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 65534,65531 stat ${n1} uid,gid
 		expect ${uidgid} lstat ${n1} uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -126,6 +130,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 -u 65532 -g 65531 -- chown ${n0} -1 -1
 		expect 65534,65533 stat ${n0} uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		uidgid=`query lstat ${n1} uid,gid`
 		expect 0 chown ${n1} 65534 65533
@@ -137,6 +142,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 65534,65533 stat ${n1} uid,gid
 		expect ${uidgid} lstat ${n1} uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -175,6 +181,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 chown ${n0} 0 0
 		expect "(06555|0555),0,0" stat ${n0} mode,uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		expect 0 chown ${n1} 65534 65533
 		expect 0 chmod ${n1} 06555
@@ -190,6 +197,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect "(06555|0555),0,0" stat ${n0} mode,uid,gid
 		expect "(06555|0555),0,0" stat ${n1} mode,uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -265,6 +273,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0 -u 65534 -g 65533,65532 -- chown ${n0} -1 -1
 		expect "(06555|0555),65534,65533" stat ${n0} mode,uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		expect 0 chown ${n1} 65534 65533
 		expect 0 chmod ${n1} 06555
@@ -290,6 +299,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect "(06555|0555),65534,65533" stat ${n0} mode,uid,gid
 		expect "(06555|0555),65534,65533" stat ${n1} mode,uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -359,6 +369,7 @@ for type in regular dir fifo block char socket symlink; do
 		ctime2=`query stat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		ctime1=`query stat ${n1} ctime`
 		nap
@@ -373,6 +384,7 @@ for type in regular dir fifo block char socket symlink; do
 		ctime2=`query stat ${n1} ctime`
 		test_check $ctime1 -lt $ctime2
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -419,6 +431,7 @@ for type in regular dir fifo block char socket symlink; do
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n0} uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		ctime1=`query stat ${n1} ctime`
 		nap
@@ -428,6 +441,7 @@ for type in regular dir fifo block char socket symlink; do
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n1} uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}
@@ -471,6 +485,7 @@ for type in regular dir fifo block char socket symlink; do
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n0} uid,gid
 
+		push_requirement ftype_symlink
 		expect 0 symlink ${n0} ${n1}
 		ctime1=`query stat ${n1} ctime`
 		nap
@@ -481,6 +496,7 @@ for type in regular dir fifo block char socket symlink; do
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n1} uid,gid
 		expect 0 unlink ${n1}
+		pop_requirement
 
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n0}

--- a/tests/chown/00.t
+++ b/tests/chown/00.t
@@ -32,7 +32,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 0,0 lstat ${n0} uid,gid
 
 		expect 0 symlink ${n0} ${n1}
-		uidgid=`${fstest} lstat ${n1} uid,gid`
+		uidgid=`query lstat ${n1} uid,gid`
 		expect 0 chown ${n1} 123 456
 		expect 123,456 stat ${n1} uid,gid
 		expect 123,456 stat ${n0} uid,gid
@@ -70,7 +70,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 65534,65531 lstat ${n0} uid,gid
 
 		expect 0 symlink ${n0} ${n1}
-		uidgid=`${fstest} lstat ${n1} uid,gid`
+		uidgid=`query lstat ${n1} uid,gid`
 		expect 0 chown ${n1} 65534 65533
 		expect 65534,65533 stat ${n0} uid,gid
 		expect 65534,65533 stat ${n1} uid,gid
@@ -117,7 +117,7 @@ for type in regular dir fifo block char socket symlink; do
 		expect 65534,65533 stat ${n0} uid,gid
 
 		expect 0 symlink ${n0} ${n1}
-		uidgid=`${fstest} lstat ${n1} uid,gid`
+		uidgid=`query lstat ${n1} uid,gid`
 		expect 0 chown ${n1} 65534 65533
 		expect 65534,65533 stat ${n0} uid,gid
 		expect 65534,65533 stat ${n1} uid,gid
@@ -324,31 +324,31 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
-		ctime1=`${fstest} stat ${n0} ctime`
+		ctime1=`query stat ${n0} ctime`
 		nap
 		expect 0 chown ${n0} 65534 65533
 		expect 65534,65533 stat ${n0} uid,gid
-		ctime2=`${fstest} stat ${n0} ctime`
+		ctime2=`query stat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
-		ctime1=`${fstest} stat ${n0} ctime`
+		ctime1=`query stat ${n0} ctime`
 		nap
 		expect 0 -u 65534 -g 65532 chown ${n0} 65534 65532
 		expect 65534,65532 stat ${n0} uid,gid
-		ctime2=`${fstest} stat ${n0} ctime`
+		ctime2=`query stat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
 
 		expect 0 symlink ${n0} ${n1}
-		ctime1=`${fstest} stat ${n1} ctime`
+		ctime1=`query stat ${n1} ctime`
 		nap
 		expect 0 chown ${n1} 65533 65532
 		expect 65533,65532 stat ${n1} uid,gid
-		ctime2=`${fstest} stat ${n1} ctime`
+		ctime2=`query stat ${n1} ctime`
 		test_check $ctime1 -lt $ctime2
-		ctime1=`${fstest} stat ${n1} ctime`
+		ctime1=`query stat ${n1} ctime`
 		nap
 		expect 0 -u 65533 -g 65531 chown ${n1} 65533 65531
 		expect 65533,65531 stat ${n1} uid,gid
-		ctime2=`${fstest} stat ${n1} ctime`
+		ctime2=`query stat ${n1} ctime`
 		test_check $ctime1 -lt $ctime2
 		expect 0 unlink ${n1}
 
@@ -361,17 +361,17 @@ for type in regular dir fifo block char socket symlink; do
 
 	create_file ${type} ${n0}
 
-	ctime1=`${fstest} lstat ${n0} ctime`
+	ctime1=`query lstat ${n0} ctime`
 	nap
 	expect 0 lchown ${n0} 65534 65533
 	expect 65534,65533 lstat ${n0} uid,gid
-	ctime2=`${fstest} lstat ${n0} ctime`
+	ctime2=`query lstat ${n0} ctime`
 	test_check $ctime1 -lt $ctime2
-	ctime1=`${fstest} lstat ${n0} ctime`
+	ctime1=`query lstat ${n0} ctime`
 	nap
 	expect 0 -u 65534 -g 65532 lchown ${n0} 65534 65532
 	expect 65534,65532 lstat ${n0} uid,gid
-	ctime2=`${fstest} lstat ${n0} ctime`
+	ctime2=`query lstat ${n0} ctime`
 	test_check $ctime1 -lt $ctime2
 
 	if [ "${type}" = "dir" ]; then
@@ -385,19 +385,19 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
-		ctime1=`${fstest} stat ${n0} ctime`
+		ctime1=`query stat ${n0} ctime`
 		nap
 		expect 0 -- chown ${n0} -1 -1
-		ctime2=`${fstest} stat ${n0} ctime`
+		ctime2=`query stat ${n0} ctime`
 		todo Linux "According to POSIX: If both owner and group are -1, the times need not be updated."
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n0} uid,gid
 
 		expect 0 symlink ${n0} ${n1}
-		ctime1=`${fstest} stat ${n1} ctime`
+		ctime1=`query stat ${n1} ctime`
 		nap
 		expect 0 -- chown ${n1} -1 -1
-		ctime2=`${fstest} stat ${n1} ctime`
+		ctime2=`query stat ${n1} ctime`
 		todo Linux "According to POSIX: If both owner and group are -1, the times need not be updated."
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n1} uid,gid
@@ -412,10 +412,10 @@ for type in regular dir fifo block char socket symlink; do
 
 	create_file ${type} ${n0}
 
-	ctime1=`${fstest} lstat ${n0} ctime`
+	ctime1=`query lstat ${n0} ctime`
 	nap
 	expect 0 -- lchown ${n0} -1 -1
-	ctime2=`${fstest} lstat ${n0} ctime`
+	ctime2=`query lstat ${n0} ctime`
 	todo Linux "According to POSIX: If both owner and group are -1, the times need not be updated."
 	test_check $ctime1 -eq $ctime2
 	expect 0,0 lstat ${n0} uid,gid
@@ -432,22 +432,22 @@ for type in regular dir fifo block char socket symlink; do
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
-		ctime1=`${fstest} stat ${n0} ctime`
+		ctime1=`query stat ${n0} ctime`
 		nap
 		expect EPERM -u 65534 -- chown ${n0} 65534 -1
 		expect EPERM -u 65534 -g 65534 -- chown ${n0} -1 65534
 		expect EPERM -u 65534 -g 65534 chown ${n0} 65534 65534
-		ctime2=`${fstest} stat ${n0} ctime`
+		ctime2=`query stat ${n0} ctime`
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n0} uid,gid
 
 		expect 0 symlink ${n0} ${n1}
-		ctime1=`${fstest} stat ${n1} ctime`
+		ctime1=`query stat ${n1} ctime`
 		nap
 		expect EPERM -u 65534 -- chown ${n1} 65534 -1
 		expect EPERM -u 65534 -g 65534 -- chown ${n1} -1 65534
 		expect EPERM -u 65534 -g 65534 chown ${n1} 65534 65534
-		ctime2=`${fstest} stat ${n1} ctime`
+		ctime2=`query stat ${n1} ctime`
 		test_check $ctime1 -eq $ctime2
 		expect 0,0 stat ${n1} uid,gid
 		expect 0 unlink ${n1}
@@ -461,12 +461,12 @@ for type in regular dir fifo block char socket symlink; do
 
 	create_file ${type} ${n0}
 
-	ctime1=`${fstest} lstat ${n0} ctime`
+	ctime1=`query lstat ${n0} ctime`
 	nap
 	expect EPERM -u 65534 -- lchown ${n0} 65534 -1
 	expect EPERM -u 65534 -g 65534 -- lchown ${n0} -1 65534
 	expect EPERM -u 65534 -g 65534 lchown ${n0} 65534 65534
-	ctime2=`${fstest} lstat ${n0} ctime`
+	ctime2=`query lstat ${n0} ctime`
 	test_check $ctime1 -eq $ctime2
 	expect 0,0 lstat ${n0} uid,gid
 

--- a/tests/chown/00.t
+++ b/tests/chown/00.t
@@ -7,6 +7,8 @@ desc="chown changes ownership"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 if supported lchmod; then
 	echo "1..1349"
 else

--- a/tests/chown/00.t
+++ b/tests/chown/00.t
@@ -325,13 +325,13 @@ for type in regular dir fifo block char socket symlink; do
 		create_file ${type} ${n0}
 
 		ctime1=`${fstest} stat ${n0} ctime`
-		sleep 1
+		nap
 		expect 0 chown ${n0} 65534 65533
 		expect 65534,65533 stat ${n0} uid,gid
 		ctime2=`${fstest} stat ${n0} ctime`
 		test_check $ctime1 -lt $ctime2
 		ctime1=`${fstest} stat ${n0} ctime`
-		sleep 1
+		nap
 		expect 0 -u 65534 -g 65532 chown ${n0} 65534 65532
 		expect 65534,65532 stat ${n0} uid,gid
 		ctime2=`${fstest} stat ${n0} ctime`
@@ -339,13 +339,13 @@ for type in regular dir fifo block char socket symlink; do
 
 		expect 0 symlink ${n0} ${n1}
 		ctime1=`${fstest} stat ${n1} ctime`
-		sleep 1
+		nap
 		expect 0 chown ${n1} 65533 65532
 		expect 65533,65532 stat ${n1} uid,gid
 		ctime2=`${fstest} stat ${n1} ctime`
 		test_check $ctime1 -lt $ctime2
 		ctime1=`${fstest} stat ${n1} ctime`
-		sleep 1
+		nap
 		expect 0 -u 65533 -g 65531 chown ${n1} 65533 65531
 		expect 65533,65531 stat ${n1} uid,gid
 		ctime2=`${fstest} stat ${n1} ctime`
@@ -362,13 +362,13 @@ for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
 
 	ctime1=`${fstest} lstat ${n0} ctime`
-	sleep 1
+	nap
 	expect 0 lchown ${n0} 65534 65533
 	expect 65534,65533 lstat ${n0} uid,gid
 	ctime2=`${fstest} lstat ${n0} ctime`
 	test_check $ctime1 -lt $ctime2
 	ctime1=`${fstest} lstat ${n0} ctime`
-	sleep 1
+	nap
 	expect 0 -u 65534 -g 65532 lchown ${n0} 65534 65532
 	expect 65534,65532 lstat ${n0} uid,gid
 	ctime2=`${fstest} lstat ${n0} ctime`
@@ -386,7 +386,7 @@ for type in regular dir fifo block char socket symlink; do
 		create_file ${type} ${n0}
 
 		ctime1=`${fstest} stat ${n0} ctime`
-		sleep 1
+		nap
 		expect 0 -- chown ${n0} -1 -1
 		ctime2=`${fstest} stat ${n0} ctime`
 		todo Linux "According to POSIX: If both owner and group are -1, the times need not be updated."
@@ -395,7 +395,7 @@ for type in regular dir fifo block char socket symlink; do
 
 		expect 0 symlink ${n0} ${n1}
 		ctime1=`${fstest} stat ${n1} ctime`
-		sleep 1
+		nap
 		expect 0 -- chown ${n1} -1 -1
 		ctime2=`${fstest} stat ${n1} ctime`
 		todo Linux "According to POSIX: If both owner and group are -1, the times need not be updated."
@@ -413,7 +413,7 @@ for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
 
 	ctime1=`${fstest} lstat ${n0} ctime`
-	sleep 1
+	nap
 	expect 0 -- lchown ${n0} -1 -1
 	ctime2=`${fstest} lstat ${n0} ctime`
 	todo Linux "According to POSIX: If both owner and group are -1, the times need not be updated."
@@ -433,7 +433,7 @@ for type in regular dir fifo block char socket symlink; do
 		create_file ${type} ${n0}
 
 		ctime1=`${fstest} stat ${n0} ctime`
-		sleep 1
+		nap
 		expect EPERM -u 65534 -- chown ${n0} 65534 -1
 		expect EPERM -u 65534 -g 65534 -- chown ${n0} -1 65534
 		expect EPERM -u 65534 -g 65534 chown ${n0} 65534 65534
@@ -443,7 +443,7 @@ for type in regular dir fifo block char socket symlink; do
 
 		expect 0 symlink ${n0} ${n1}
 		ctime1=`${fstest} stat ${n1} ctime`
-		sleep 1
+		nap
 		expect EPERM -u 65534 -- chown ${n1} 65534 -1
 		expect EPERM -u 65534 -g 65534 -- chown ${n1} -1 65534
 		expect EPERM -u 65534 -g 65534 chown ${n1} 65534 65534
@@ -462,7 +462,7 @@ for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
 
 	ctime1=`${fstest} lstat ${n0} ctime`
-	sleep 1
+	nap
 	expect EPERM -u 65534 -- lchown ${n0} 65534 -1
 	expect EPERM -u 65534 -g 65534 -- lchown ${n0} -1 65534
 	expect EPERM -u 65534 -g 65534 lchown ${n0} 65534 65534

--- a/tests/chown/00.t
+++ b/tests/chown/00.t
@@ -23,6 +23,8 @@ cd ${n2}
 
 # super-user can always modify ownership
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -54,11 +56,15 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 # non-super-user can modify file group if he is owner of a file and
 # gid he is setting is in his groups list.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -104,11 +110,15 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 # chown(2) return 0 if user is not owner of a file, but chown(2) is called
 # with both uid and gid equal to -1.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -144,10 +154,14 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 # when super-user calls chown(2), set-uid and set-gid bits may be removed.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -209,11 +223,15 @@ for type in regular dir fifo block char socket symlink; do
 			expect 0 unlink ${n0}
 		fi
 	fi
+
+	pop_requirement
 done
 
 # when non-super-user calls chown(2) successfully, set-uid and set-gid bits may
 # be removed, except when both uid and gid are equal to -1.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	#
 	# Linux makes a destinction for behavior when an executable file vs a
 	# non-executable file. From chmod(2):
@@ -317,10 +335,14 @@ for type in regular dir fifo block char socket symlink; do
 			expect 0 unlink ${n0}
 		fi
 	fi
+
+	pop_requirement
 done
 
 # successful chown(2) call (except uid and gid equal to -1) updates ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -379,9 +401,13 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -425,10 +451,14 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 # unsuccessful chown(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 
@@ -475,6 +505,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/chown/01.t
+++ b/tests/chown/01.t
@@ -14,9 +14,13 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR chown ${n0}/${n1}/test 65534 65534
 	expect ENOTDIR lchown ${n0}/${n1}/test 65534 65534
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/chown/02.t
+++ b/tests/chown/02.t
@@ -7,6 +7,8 @@ desc="chown returns ENAMETOOLONG if a component of a pathname exceeded ${NAME_MA
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..10"
 
 nx=`namegen_max`

--- a/tests/chown/03.t
+++ b/tests/chown/03.t
@@ -7,6 +7,8 @@ desc="chown returns ENAMETOOLONG if an entire path name exceeded {PATH_MAX} char
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..10"
 
 nx=`dirgen_max`

--- a/tests/chown/04.t
+++ b/tests/chown/04.t
@@ -18,7 +18,11 @@ expect ENOENT chown ${n0}/${n1}/test 65534 65534
 expect ENOENT chown ${n0}/${n1} 65534 65534
 expect ENOENT lchown ${n0}/${n1}/test 65534 65534
 expect ENOENT lchown ${n0}/${n1} 65534 65534
+
+push_requirement ftype_symlink
 expect 0 symlink ${n2} ${n0}/${n1}
 expect ENOENT chown ${n0}/${n1} 65534 65534
 expect 0 unlink ${n0}/${n1}
+pop_requirement
+
 expect 0 rmdir ${n0}

--- a/tests/chown/05.t
+++ b/tests/chown/05.t
@@ -7,6 +7,8 @@ desc="chown returns EACCES when search permission is denied for a component of t
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..18"
 
 n0=`namegen`

--- a/tests/chown/06.t
+++ b/tests/chown/06.t
@@ -7,6 +7,8 @@ desc="chown returns ELOOP if too many symbolic links were encountered in transla
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/chown/07.t
+++ b/tests/chown/07.t
@@ -20,6 +20,8 @@ cd ${n0}
 expect 0 mkdir ${n1} 0755
 expect 0 chown ${n1} 65534 65534
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n1}/${n2} 65534 65534
 		expect EPERM -u 65534 -g 65534 chown ${n1}/${n2} 65533 65533
@@ -48,6 +50,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}/${n2}
 	fi
+
+	pop_requirement
 done
 expect 0 rmdir ${n1}
 cd ${cdir}

--- a/tests/chown/07.t
+++ b/tests/chown/07.t
@@ -7,6 +7,8 @@ desc="chown returns EPERM if the operation would change the ownership, but the e
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..132"
 
 n0=`namegen`

--- a/tests/chown/07.t
+++ b/tests/chown/07.t
@@ -28,12 +28,16 @@ for type in regular dir fifo block char socket symlink; do
 		expect EPERM -u 65533 -g 65533 chown ${n1}/${n2} 65534 65534
 		expect EPERM -u 65533 -g 65533 chown ${n1}/${n2} 65533 65533
 		expect EPERM -u 65534 -g 65534 -- chown ${n1}/${n2} -1 65533
+
+		push_requirement ftype_symlink
 		expect 0 -u 65534 -g 65534 symlink ${n2} ${n1}/${n3}
 		expect EPERM -u 65534 -g 65534 chown ${n1}/${n3} 65533 65533
 		expect EPERM -u 65533 -g 65533 chown ${n1}/${n3} 65534 65534
 		expect EPERM -u 65533 -g 65533 chown ${n1}/${n3} 65533 65533
 		expect EPERM -u 65534 -g 65534 -- chown ${n1}/${n3} -1 65533
 		expect 0 unlink ${n1}/${n3}
+		pop_requirement
+
 		if [ "${type}" = "dir" ]; then
 			expect 0 rmdir ${n1}/${n2}
 		else

--- a/tests/ftruncate/00.t
+++ b/tests/ftruncate/00.t
@@ -39,6 +39,8 @@ ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
+push_requirement root
+
 # unsuccessful ftruncate(2) does not update ctime.
 expect 0 create ${n0} 0644
 ctime1=`query stat ${n0} ctime`
@@ -56,6 +58,8 @@ expect 0 unlink ${n0}
 expect 0 chmod . 0777
 expect 0 -u 65534 open ${n0} O_CREAT,O_RDWR 0 : ftruncate 0 0
 expect 0 unlink ${n0}
+
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n1}

--- a/tests/ftruncate/00.t
+++ b/tests/ftruncate/00.t
@@ -33,7 +33,7 @@ expect 0 unlink ${n0}
 # successful ftruncate(2) updates ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 open ${n0} O_RDWR : ftruncate 0 123
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -42,7 +42,7 @@ expect 0 unlink ${n0}
 # unsuccessful ftruncate(2) does not update ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EINVAL -u 65534 open ${n0} O_RDONLY : ftruncate 0 123
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2

--- a/tests/ftruncate/00.t
+++ b/tests/ftruncate/00.t
@@ -32,19 +32,19 @@ expect 0 unlink ${n0}
 
 # successful ftruncate(2) updates ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 open ${n0} O_RDWR : ftruncate 0 123
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 # unsuccessful ftruncate(2) does not update ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EINVAL -u 65534 open ${n0} O_RDONLY : ftruncate 0 123
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 

--- a/tests/ftruncate/05.t
+++ b/tests/ftruncate/05.t
@@ -7,6 +7,8 @@ desc="truncate returns EACCES when search permission is denied for a component o
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..15"
 
 n0=`namegen`

--- a/tests/ftruncate/06.t
+++ b/tests/ftruncate/06.t
@@ -7,6 +7,8 @@ desc="truncate returns EACCES if the named file is not writable by the user"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..8"
 
 n0=`namegen`

--- a/tests/ftruncate/07.t
+++ b/tests/ftruncate/07.t
@@ -7,6 +7,8 @@ desc="truncate returns ELOOP if too many symbolic links were encountered in tran
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/ftruncate/08.t
+++ b/tests/ftruncate/08.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..22"
-	;;
-FreeBSD:UFS)
-	echo "1..44"
-	;;
-*)
-	quick_exit
-esac
+echo "1..44"
 
 n0=`namegen`
 
@@ -49,8 +40,7 @@ expect 0 truncate ${n0} 123
 expect 123 stat ${n0} size
 expect 0 unlink ${n0}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM truncate ${n0} 123
@@ -59,14 +49,18 @@ FreeBSD:UFS)
 	expect 0 truncate ${n0} 123
 	expect 123 stat ${n0} size
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 truncate ${n0} 123
 	expect 123 stat ${n0} size
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM truncate ${n0} 123
@@ -75,5 +69,4 @@ FreeBSD:UFS)
 	expect 0 truncate ${n0} 123
 	expect 123 stat ${n0} size
 	expect 0 unlink ${n0}
-	;;
-esac
+pop_requirement

--- a/tests/ftruncate/12.t
+++ b/tests/ftruncate/12.t
@@ -21,7 +21,7 @@ EFBIG|EINVAL)
 	expect 999999999999999 stat ${n0} size
 	;;
 *)
-	echo "not ok ${ntest}"
+	echo "not ok ${ntest} returned '${r}'"
 	ntest=`expr ${ntest} + 1`
 	;;
 esac

--- a/tests/ftruncate/12.t
+++ b/tests/ftruncate/12.t
@@ -12,7 +12,7 @@ echo "1..3"
 n0=`namegen`
 
 expect 0 create ${n0} 0644
-r=`${fstest} truncate ${n0} 999999999999999 2>/dev/null`
+r=`query truncate ${n0} 999999999999999 2>/dev/null`
 case "${r}" in
 EFBIG|EINVAL)
 	expect 0 stat ${n0} size

--- a/tests/link/00.t
+++ b/tests/link/00.t
@@ -62,7 +62,7 @@ for type in regular fifo block char socket; do
 	ctime1=`${fstest} stat ${n0} ctime`
 	dctime1=`${fstest} stat . ctime`
 	dmtime1=`${fstest} stat . mtime`
-	sleep 1
+	nap
 	expect 0 link ${n0} ${n1}
 	ctime2=`${fstest} stat ${n0} ctime`
 	test_check $ctime1 -lt $ctime2
@@ -81,7 +81,7 @@ for type in regular fifo block char socket; do
 	ctime1=`${fstest} stat ${n0} ctime`
 	dctime1=`${fstest} stat . ctime`
 	dmtime1=`${fstest} stat . mtime`
-	sleep 1
+	nap
 	expect EACCES -u 65534 link ${n0} ${n1}
 	ctime2=`${fstest} stat ${n0} ctime`
 	test_check $ctime1 -eq $ctime2

--- a/tests/link/00.t
+++ b/tests/link/00.t
@@ -20,6 +20,7 @@ expect 0 mkdir ${n3} 0755
 cdir=`pwd`
 cd ${n3}
 
+push_requirement root
 for type in regular fifo block char socket; do
 	push_requirement ftype_${type}
 
@@ -59,6 +60,7 @@ for type in regular fifo block char socket; do
 
 	pop_requirement
 done
+pop_requirement
 
 # successful link(2) updates ctime.
 for type in regular fifo block char socket; do
@@ -83,6 +85,7 @@ for type in regular fifo block char socket; do
 done
 
 # unsuccessful link(2) does not update ctime.
+push_requirement root
 for type in regular fifo block char socket; do
 	push_requirement ftype_${type}
 
@@ -103,6 +106,7 @@ for type in regular fifo block char socket; do
 
 	pop_requirement
 done
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n3}

--- a/tests/link/00.t
+++ b/tests/link/00.t
@@ -59,16 +59,16 @@ done
 # successful link(2) updates ctime.
 for type in regular fifo block char socket; do
 	create_file ${type} ${n0}
-	ctime1=`${fstest} stat ${n0} ctime`
-	dctime1=`${fstest} stat . ctime`
-	dmtime1=`${fstest} stat . mtime`
+	ctime1=`query stat ${n0} ctime`
+	dctime1=`query stat . ctime`
+	dmtime1=`query stat . mtime`
 	nap
 	expect 0 link ${n0} ${n1}
-	ctime2=`${fstest} stat ${n0} ctime`
+	ctime2=`query stat ${n0} ctime`
 	test_check $ctime1 -lt $ctime2
-	dctime2=`${fstest} stat . ctime`
+	dctime2=`query stat . ctime`
 	test_check $dctime1 -lt $dctime2
-	dmtime2=`${fstest} stat . mtime`
+	dmtime2=`query stat . mtime`
 	test_check $dctime1 -lt $dmtime2
 	expect 0 unlink ${n0}
 	expect 0 unlink ${n1}
@@ -78,16 +78,16 @@ done
 for type in regular fifo block char socket; do
 	create_file ${type} ${n0}
 	expect 0 -- chown ${n0} 65534 -1
-	ctime1=`${fstest} stat ${n0} ctime`
-	dctime1=`${fstest} stat . ctime`
-	dmtime1=`${fstest} stat . mtime`
+	ctime1=`query stat ${n0} ctime`
+	dctime1=`query stat . ctime`
+	dmtime1=`query stat . mtime`
 	nap
 	expect EACCES -u 65534 link ${n0} ${n1}
-	ctime2=`${fstest} stat ${n0} ctime`
+	ctime2=`query stat ${n0} ctime`
 	test_check $ctime1 -eq $ctime2
-	dctime2=`${fstest} stat . ctime`
+	dctime2=`query stat . ctime`
 	test_check $dctime1 -eq $dctime2
-	dmtime2=`${fstest} stat . mtime`
+	dmtime2=`query stat . mtime`
 	test_check $dctime1 -eq $dmtime2
 	expect 0 unlink ${n0}
 done

--- a/tests/link/00.t
+++ b/tests/link/00.t
@@ -21,6 +21,8 @@ cdir=`pwd`
 cd ${n3}
 
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect ${type},1 lstat ${n0} type,nlink
 
@@ -54,10 +56,14 @@ for type in regular fifo block char socket; do
 	expect ENOENT lstat ${n0} type,mode,nlink,uid,gid
 	expect ENOENT lstat ${n1} type,mode,nlink,uid,gid
 	expect ENOENT lstat ${n2} type,mode,nlink,uid,gid
+
+	pop_requirement
 done
 
 # successful link(2) updates ctime.
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	ctime1=`query stat ${n0} ctime`
 	dctime1=`query stat . ctime`
@@ -72,10 +78,14 @@ for type in regular fifo block char socket; do
 	test_check $dctime1 -lt $dmtime2
 	expect 0 unlink ${n0}
 	expect 0 unlink ${n1}
+
+	pop_requirement
 done
 
 # unsuccessful link(2) does not update ctime.
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect 0 -- chown ${n0} 65534 -1
 	ctime1=`query stat ${n0} ctime`
@@ -90,6 +100,8 @@ for type in regular fifo block char socket; do
 	dmtime2=`query stat . mtime`
 	test_check $dctime1 -eq $dmtime2
 	expect 0 unlink ${n0}
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/link/01.t
+++ b/tests/link/01.t
@@ -17,11 +17,15 @@ n2=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR link ${n0}/${n1}/test ${n0}/${n2}
 	create_file ${type} ${n0}/${n2}
 	expect ENOTDIR link ${n0}/${n2} ${n0}/${n1}/test
 	expect 0 unlink ${n0}/${n1}
 	expect 0 unlink ${n0}/${n2}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/link/06.t
+++ b/tests/link/06.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require link
+require root
 
 echo "1..18"
 

--- a/tests/link/07.t
+++ b/tests/link/07.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require link
+require root
 
 echo "1..17"
 

--- a/tests/link/10.t
+++ b/tests/link/10.t
@@ -17,6 +17,8 @@ n1=`namegen`
 expect 0 create ${n0} 0644
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n1}
 	expect EEXIST link ${n0} ${n1}
 	if [ "${type}" = "dir" ]; then
@@ -24,6 +26,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 expect 0 unlink ${n0}

--- a/tests/link/11.t
+++ b/tests/link/11.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require link
+require root
 
 n0=`namegen`
 n1=`namegen`

--- a/tests/link/12.t
+++ b/tests/link/12.t
@@ -10,16 +10,7 @@ dir=`dirname $0`
 require chflags
 require link
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..28"
-	;;
-FreeBSD:UFS)
-	echo "1..48"
-	;;
-*)
-	quick_exit
-esac
+echo "1..48"
 
 n0=`namegen`
 n1=`namegen`
@@ -56,8 +47,7 @@ expect 2 stat ${n0} nlink
 expect 0 unlink ${n1}
 expect 1 stat ${n0} nlink
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM link ${n0} ${n1}
 	expect 0 chflags ${n0} none
@@ -65,14 +55,18 @@ FreeBSD:UFS)
 	expect 2 stat ${n0} nlink
 	expect 0 unlink ${n1}
 	expect 1 stat ${n0} nlink
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 link ${n0} ${n1}
 	expect 2 stat ${n0} nlink
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n1}
 	expect 1 stat ${n0} nlink
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM link ${n0} ${n1}
 	expect 0 chflags ${n0} none
@@ -80,7 +74,6 @@ FreeBSD:UFS)
 	expect 2 stat ${n0} nlink
 	expect 0 unlink ${n1}
 	expect 1 stat ${n0} nlink
-	;;
-esac
+pop_requirement
 
 expect 0 unlink ${n0}

--- a/tests/link/13.t
+++ b/tests/link/13.t
@@ -10,16 +10,7 @@ dir=`dirname $0`
 require chflags
 require link
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..29"
-	;;
-FreeBSD:UFS)
-	echo "1..49"
-	;;
-*)
-	quick_exit
-esac
+echo "1..49"
 
 n0=`namegen`
 n1=`namegen`
@@ -57,8 +48,7 @@ expect 0 chflags ${n0} none
 expect 0 unlink ${n0}/${n2}
 expect 1 stat ${n0}/${n1} nlink
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM link ${n0}/${n1} ${n0}/${n2}
 	expect 1 stat ${n0}/${n1} nlink
@@ -67,22 +57,25 @@ FreeBSD:UFS)
 	expect 2 stat ${n0}/${n1} nlink
 	expect 0 unlink ${n0}/${n2}
 	expect 1 stat ${n0}/${n1} nlink
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 link ${n0}/${n1} ${n0}/${n2}
 	expect 2 stat ${n0}/${n1} nlink
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n2}
 	expect 1 stat ${n0}/${n1} nlink
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 link ${n0}/${n1} ${n0}/${n2}
 	expect 2 stat ${n0}/${n1} nlink
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n2}
 	expect 1 stat ${n0}/${n1} nlink
-	;;
-esac
+pop_requirement
 
 expect 0 unlink ${n0}/${n1}
 expect 0 rmdir ${n0}

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -38,6 +38,7 @@ requires_root()
 
 expect()
 {
+	local e r
 	e="${1}"
 	shift
 	r=`${fstest} $* 2>/dev/null | tail -1`
@@ -61,6 +62,7 @@ expect()
 
 jexpect()
 {
+	local s d e r
 	s="${1}"
 	d="${2}"
 	e="${3}"
@@ -118,6 +120,7 @@ namegen()
 
 namegen_len()
 {
+	local len name namepart curlen
 	len="${1}"
 
 	name=""
@@ -136,6 +139,7 @@ namegen_len()
 #     Maximum number of bytes in a filename (not including terminating null).
 namegen_max()
 {
+	local name_max
 	name_max=`${fstest} pathconf . _PC_NAME_MAX`
 	namegen_len ${name_max}
 }
@@ -145,6 +149,7 @@ namegen_max()
 #     Maximum number of bytes in a pathname, including the terminating null character.
 dirgen_max()
 {
+	local name_max complen path_max name curlen
 	name_max=`${fstest} pathconf . _PC_NAME_MAX`
 	complen=$((name_max/2))
 	path_max=`${fstest} pathconf . _PC_PATH_MAX`
@@ -331,6 +336,7 @@ fi
 #	create_file <type> <name> <uid> <gid>
 #	create_file <type> <name> <mode> <uid> <gid>
 create_file() {
+	local type name
 	type="${1}"
 	name="${2}"
 

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -293,8 +293,6 @@ supported()
 			return 1
 		fi
 		;;
-	mknod)
-		;;
 	posix_fallocate)
 		if [ "${os}" != "FreeBSD" ]; then
 			return 1

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -44,7 +44,7 @@ expect()
 	echo "${r}" | ${GREP} -Eq '^'${e}'$'
 	if [ $? -eq 0 ]; then
 		if [ -z "${todomsg}" ]; then
-			echo "ok ${ntest}"
+			echo "ok ${ntest} -- $*"
 		else
 			echo "ok ${ntest} # TODO ${todomsg}"
 		fi
@@ -70,7 +70,7 @@ jexpect()
 	echo "${r}" | ${GREP} -Eq '^'${e}'$'
 	if [ $? -eq 0 ]; then
 		if [ -z "${todomsg}" ]; then
-			echo "ok ${ntest}"
+			echo "ok ${ntest} -- $*"
 		else
 			echo "ok ${ntest} # TODO ${todomsg}"
 		fi
@@ -89,7 +89,7 @@ test_check()
 {
 	if [ $* ] 2>/dev/null ; then
 		if [ -z "${todomsg}" ]; then
-			echo "ok ${ntest}"
+			echo "ok ${ntest} -- $*"
 		else
 			echo "ok ${ntest} # TODO ${todomsg}"
 		fi

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -206,7 +206,32 @@ supported()
 			return 1
 		fi
 		;;
+	chflags_SF_ARCHIVED)
+		if [ "${os}" != "FreeBSD" -o "${fs}" != "UFS" ]; then
+			return 1
+		fi
+		;;
 	chflags_SF_SNAPSHOT)
+		if [ "${os}" != "FreeBSD" -o "${fs}" != "UFS" ]; then
+			return 1
+		fi
+		;;
+	chflags_UF_APPEND)
+		if [ "${os}" != "FreeBSD" -o "${fs}" != "UFS" ]; then
+			return 1
+		fi
+		;;
+	chflags_UF_IMMUTABLE)
+		if [ "${os}" != "FreeBSD" -o "${fs}" != "UFS" ]; then
+			return 1
+		fi
+		;;
+	chflags_UF_NOUNLINK)
+		if [ "${os}" != "FreeBSD" -o "${fs}" != "UFS" ]; then
+			return 1
+		fi
+		;;
+	chflags_UF_OPAQUE)
 		if [ "${os}" != "FreeBSD" -o "${fs}" != "UFS" ]; then
 			return 1
 		fi

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -171,6 +171,11 @@ nap() {
 	sleep 1
 }
 
+query()
+{
+	${fstest} $*
+}
+
 quick_exit()
 {
 	echo "1..1"

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -23,19 +23,6 @@ if [ ! -x $fstest ]; then
 	exit 1
 fi
 
-requires_root()
-{
-	case "$(id -u)" in
-	0)
-		return 0
-		;;
-	*)
-		echo "not ok ${ntest} not root"
-		return 1
-		;;
-	esac
-}
-
 expect()
 {
 	local e r
@@ -239,6 +226,11 @@ supported()
 			return 1;
 			;;
 		esac
+		;;
+	root)
+		if [ "$(id -u)" != "0" ]; then
+			return 1
+		fi
 		;;
 	stat_st_birthtime)
 		case "${os}" in

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -95,7 +95,7 @@ test_check()
 		fi
 	else
 		if [ -z "${todomsg}" ]; then
-			echo "not ok ${ntest}"
+			echo "not ok ${ntest} - expected '$*'"
 		else
 			echo "not ok ${ntest} # TODO ${todomsg}"
 		fi
@@ -258,10 +258,10 @@ supported()
 
 require()
 {
-	if supported ${1}; then
-		return
+	if ! supported ${1}; then
+		echo "1..0 # SKIP '${1}' unsupported"
+		exit 0
 	fi
-	quick_exit
 }
 
 if [ "${os}" = "FreeBSD" ]; then

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -50,7 +50,7 @@ expect()
 		fi
 	else
 		if [ -z "${todomsg}" ]; then
-			echo "not ok ${ntest} - tried '$*', expected ${e}, got ${r}"
+			echo "not ok ${ntest} - tried '$*', expected '${e}', got '${r}'"
 		else
 			echo "not ok ${ntest} # TODO ${todomsg}"
 		fi
@@ -76,7 +76,7 @@ jexpect()
 		fi
 	else
 		if [ -z "${todomsg}" ]; then
-			echo "not ok ${ntest} - tried '$*', expected ${e}, got ${r}"
+			echo "not ok ${ntest} - tried '$*', expected '${e}', got '${r}'"
 		else
 			echo "not ok ${ntest} # TODO ${todomsg}"
 		fi

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -167,6 +167,10 @@ dirgen_max()
 	printf "%s" "${name}"
 }
 
+nap() {
+	sleep 1
+}
+
 quick_exit()
 {
 	echo "1..1"

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -252,6 +252,10 @@ supported()
 			return 1
 		fi
 		;;
+	*)
+		echo "not ok unknown feature '${r}'"
+		exit 1
+		;;
 	esac
 	return 0
 }

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -47,6 +47,14 @@ expect()
 	local e r
 	e="${1}"
 	shift
+
+	if [ ${skipmsg} ]; then
+		echo "ok ${ntest} # SKIP '${skipmsg}'"
+		todomsg=""
+		ntest=$((ntest+1))
+		return
+	fi
+
 	r=`${fstest} $* 2>/dev/null | tail -1`
 	echo "${r}" | ${GREP} -Eq '^'${e}'$'
 	if [ $? -eq 0 ]; then
@@ -72,8 +80,15 @@ jexpect()
 	s="${1}"
 	d="${2}"
 	e="${3}"
-
 	shift 3
+
+	if [ ${skipmsg} ]; then
+		echo "ok ${ntest} # SKIP '${skipmsg}'"
+		todomsg=""
+		ntest=$((ntest+1))
+		return
+	fi
+
 	r=`jail -s ${s} / pjdfstest 127.0.0.1 /bin/sh -c "cd ${d} && ${fstest} $* 2>/dev/null" 2>/dev/null | tail -1`
 	echo "${r}" | ${GREP} -Eq '^'${e}'$'
 	if [ $? -eq 0 ]; then
@@ -95,6 +110,13 @@ jexpect()
 
 test_check()
 {
+	if [ ${skipmsg} ]; then
+		echo "ok ${ntest} # SKIP '${skipmsg}'"
+		todomsg=""
+		ntest=$((ntest+1))
+		return
+	fi
+
 	if [ $* ] 2>/dev/null ; then
 		if [ -z "${todomsg}" ]; then
 			echo "ok ${ntest} -- $*"
@@ -174,11 +196,19 @@ dirgen_max()
 }
 
 nap() {
+	if [ ${skipmsg} ]; then
+		return
+	fi
+
 	sleep 1
 }
 
 query()
 {
+	if [ ${skipmsg} ]; then
+		return
+	fi
+
 	${fstest} $*
 }
 

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -23,6 +23,25 @@ if [ ! -x $fstest ]; then
 	exit 1
 fi
 
+requirements=""
+skipmsg=""
+
+push_requirement() {
+	requirements="${1} ${requirements}"
+	skipmsg=""
+	for r in ${requirements}; do
+		if ! supported ${r}; then
+			skipmsg=${r}
+			break
+		fi
+	done
+}
+
+pop_requirement() {
+	requirements="`echo ${requirements} | sed 's/^ *[^ ]\\+ *//'`"
+	push_requirement ""
+}
+
 expect()
 {
 	local e r

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -211,6 +211,28 @@ supported()
 			return 1
 		fi
 		;;
+	ftype_block)
+		if ! supported root; then
+			return 1
+		fi
+		;;
+	ftype_char)
+		if ! supported root; then
+			return 1
+		fi
+		;;
+	ftype_dir)
+		;;
+	ftype_fifo)
+		;;
+	ftype_none)
+		;;
+	ftype_regular)
+		;;
+	ftype_socket)
+		;;
+	ftype_symlink)
+		;;
 	link)
 		if [ "${fs}" = "FUSE.GCSFUSE" -o "${fs}" = "FUSE.S3FS" ]; then
 			return 1

--- a/tests/mkdir/00.t
+++ b/tests/mkdir/00.t
@@ -57,6 +57,7 @@ expect 0 rmdir ${n0}
 # POSIX: The directory's user ID shall be set to the process' effective user ID.
 # The directory's group ID shall be set to the group ID of the parent directory
 # or to the effective group ID of the process.
+push_requirement root
 expect 0 chown . 65535 65535
 expect 0 -u 65535 -g 65535 mkdir ${n0} 0755
 expect 65535,65535 lstat ${n0} uid,gid
@@ -68,6 +69,7 @@ expect 0 chmod . 0777
 expect 0 -u 65534 -g 65533 mkdir ${n0} 0755
 expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 rmdir ${n0}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n1}

--- a/tests/mkdir/00.t
+++ b/tests/mkdir/00.t
@@ -35,21 +35,6 @@ expect 0 -U 0501 mkdir ${n0} 0345
 expect dir,0244 lstat ${n0} type,mode
 expect 0 rmdir ${n0}
 
-# POSIX: The directory's user ID shall be set to the process' effective user ID.
-# The directory's group ID shall be set to the group ID of the parent directory
-# or to the effective group ID of the process.
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 mkdir ${n0} 0755
-expect 65535,65535 lstat ${n0} uid,gid
-expect 0 rmdir ${n0}
-expect 0 -u 65535 -g 65534 mkdir ${n0} 0755
-expect "65535,6553[45]" lstat ${n0} uid,gid
-expect 0 rmdir ${n0}
-expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 mkdir ${n0} 0755
-expect "65534,6553[35]" lstat ${n0} uid,gid
-expect 0 rmdir ${n0}
-
 # POSIX: Upon successful completion, mkdir() shall mark for update the st_atime,
 # st_ctime, and st_mtime fields of the directory. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
@@ -68,6 +53,21 @@ mtime=`${fstest} stat . mtime`
 test_check $time -lt $mtime
 ctime=`${fstest} stat . ctime`
 test_check $time -lt $ctime
+expect 0 rmdir ${n0}
+
+# POSIX: The directory's user ID shall be set to the process' effective user ID.
+# The directory's group ID shall be set to the group ID of the parent directory
+# or to the effective group ID of the process.
+expect 0 chown . 65535 65535
+expect 0 -u 65535 -g 65535 mkdir ${n0} 0755
+expect 65535,65535 lstat ${n0} uid,gid
+expect 0 rmdir ${n0}
+expect 0 -u 65535 -g 65534 mkdir ${n0} 0755
+expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 rmdir ${n0}
+expect 0 chmod . 0777
+expect 0 -u 65534 -g 65533 mkdir ${n0} 0755
+expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 rmdir ${n0}
 
 cd ${cdir}

--- a/tests/mkdir/00.t
+++ b/tests/mkdir/00.t
@@ -40,7 +40,7 @@ expect 0 rmdir ${n0}
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
 time=`${fstest} stat . ctime`
-sleep 1
+nap
 expect 0 mkdir ${n0} 0755
 atime=`${fstest} stat ${n0} atime`
 test_check $time -lt $atime

--- a/tests/mkdir/00.t
+++ b/tests/mkdir/00.t
@@ -7,7 +7,7 @@ desc="mkdir creates directories"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..36"
+echo "1..35"
 
 n0=`namegen`
 n1=`namegen`
@@ -39,7 +39,6 @@ expect 0 rmdir ${n0}
 # st_ctime, and st_mtime fields of the directory. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
-expect 0 chown . 0 0
 time=`${fstest} stat . ctime`
 sleep 1
 expect 0 mkdir ${n0} 0755

--- a/tests/mkdir/00.t
+++ b/tests/mkdir/00.t
@@ -39,18 +39,18 @@ expect 0 rmdir ${n0}
 # st_ctime, and st_mtime fields of the directory. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
-time=`${fstest} stat . ctime`
+time=`query stat . ctime`
 nap
 expect 0 mkdir ${n0} 0755
-atime=`${fstest} stat ${n0} atime`
+atime=`query stat ${n0} atime`
 test_check $time -lt $atime
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
-mtime=`${fstest} stat . mtime`
+mtime=`query stat . mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat . ctime`
+ctime=`query stat . ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 

--- a/tests/mkdir/01.t
+++ b/tests/mkdir/01.t
@@ -14,8 +14,12 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR mkdir ${n0}/${n1}/test 0755
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/mkdir/05.t
+++ b/tests/mkdir/05.t
@@ -7,6 +7,8 @@ desc="mkdir returns EACCES when search permission is denied for a component of t
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/mkdir/06.t
+++ b/tests/mkdir/06.t
@@ -7,6 +7,8 @@ desc="mkdir returns EACCES when write permission is denied on the parent directo
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/mkdir/07.t
+++ b/tests/mkdir/07.t
@@ -7,6 +7,8 @@ desc="mkdir returns ELOOP if too many symbolic links were encountered in transla
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/mkdir/08.t
+++ b/tests/mkdir/08.t
@@ -44,24 +44,26 @@ expect 0 mkdir ${n0}/${n1} 0755
 expect 0 chflags ${n0} none
 expect 0 rmdir ${n0}/${n1}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM mkdir ${n0}/${n1} 0755
 	expect 0 chflags ${n0} none
 	expect 0 mkdir ${n0}/${n1} 0755
 	expect 0 rmdir ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 mkdir ${n0}/${n1} 0755
 	expect 0 rmdir ${n0}/${n1}
 	expect 0 chflags ${n0} none
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 mkdir ${n0}/${n1} 0755
 	expect 0 chflags ${n0} none
 	expect 0 rmdir ${n0}/${n1}
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/mkdir/10.t
+++ b/tests/mkdir/10.t
@@ -12,6 +12,8 @@ echo "1..21"
 n0=`namegen`
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect EEXIST mkdir ${n0} 0755
 	if [ "${type}" = "dir" ]; then
@@ -19,4 +21,6 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -7,6 +7,8 @@ desc="mkfifo creates fifo files"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..35"
 
 n0=`namegen`

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -39,18 +39,18 @@ expect 0 unlink ${n0}
 # st_atime, st_ctime, and st_mtime fields of the file. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
-time=`${fstest} stat . ctime`
+time=`query stat . ctime`
 nap
 expect 0 mkfifo ${n0} 0755
-atime=`${fstest} stat ${n0} atime`
+atime=`query stat ${n0} atime`
 test_check $time -lt $atime
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
-mtime=`${fstest} stat . mtime`
+mtime=`query stat . mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat . ctime`
+ctime=`query stat . ctime`
 test_check $time -lt $ctime
 expect 0 unlink ${n0}
 

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -59,6 +59,7 @@ expect 0 unlink ${n0}
 # POSIX: The FIFO's user ID shall be set to the process' effective user ID.
 # The FIFO's group ID shall be set to the group ID of the parent directory or to
 # the effective group ID of the process.
+push_requirement root
 expect 0 chown . 65535 65535
 expect 0 -u 65535 -g 65535 mkfifo ${n0} 0755
 expect 65535,65535 lstat ${n0} uid,gid
@@ -70,6 +71,7 @@ expect 0 chmod . 0777
 expect 0 -u 65534 -g 65533 mkfifo ${n0} 0755
 expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n1}

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -40,7 +40,7 @@ expect 0 unlink ${n0}
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
 time=`${fstest} stat . ctime`
-sleep 1
+nap
 expect 0 mkfifo ${n0} 0755
 atime=`${fstest} stat ${n0} atime`
 test_check $time -lt $atime

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -7,7 +7,7 @@ desc="mkfifo creates fifo files"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..36"
+echo "1..35"
 
 n0=`namegen`
 n1=`namegen`
@@ -39,7 +39,6 @@ expect 0 unlink ${n0}
 # st_atime, st_ctime, and st_mtime fields of the file. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
-expect 0 chown . 0 0
 time=`${fstest} stat . ctime`
 sleep 1
 expect 0 mkfifo ${n0} 0755

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -35,21 +35,6 @@ expect 0 -U 0501 mkfifo ${n0} 0345
 expect fifo,0244 lstat ${n0} type,mode
 expect 0 unlink ${n0}
 
-# POSIX: The FIFO's user ID shall be set to the process' effective user ID.
-# The FIFO's group ID shall be set to the group ID of the parent directory or to
-# the effective group ID of the process.
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 mkfifo ${n0} 0755
-expect 65535,65535 lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 -u 65535 -g 65534 mkfifo ${n0} 0755
-expect "65535,6553[45]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 mkfifo ${n0} 0755
-expect "65534,6553[35]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-
 # POSIX: Upon successful completion, mkfifo() shall mark for update the
 # st_atime, st_ctime, and st_mtime fields of the file. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
@@ -68,6 +53,21 @@ mtime=`${fstest} stat . mtime`
 test_check $time -lt $mtime
 ctime=`${fstest} stat . ctime`
 test_check $time -lt $ctime
+expect 0 unlink ${n0}
+
+# POSIX: The FIFO's user ID shall be set to the process' effective user ID.
+# The FIFO's group ID shall be set to the group ID of the parent directory or to
+# the effective group ID of the process.
+expect 0 chown . 65535 65535
+expect 0 -u 65535 -g 65535 mkfifo ${n0} 0755
+expect 65535,65535 lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+expect 0 -u 65535 -g 65534 mkfifo ${n0} 0755
+expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+expect 0 chmod . 0777
+expect 0 -u 65534 -g 65533 mkfifo ${n0} 0755
+expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 
 cd ${cdir}

--- a/tests/mkfifo/01.t
+++ b/tests/mkfifo/01.t
@@ -7,6 +7,8 @@ desc="mkfifo returns ENOTDIR if a component of the path prefix is not a director
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..17"
 
 n0=`namegen`

--- a/tests/mkfifo/01.t
+++ b/tests/mkfifo/01.t
@@ -14,8 +14,12 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR mkfifo ${n0}/${n1}/test 0644
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/mkfifo/02.t
+++ b/tests/mkfifo/02.t
@@ -7,6 +7,8 @@ desc="mkfifo returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MA
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..4"
 
 nx=`namegen_max`

--- a/tests/mkfifo/03.t
+++ b/tests/mkfifo/03.t
@@ -7,6 +7,8 @@ desc="mkfifo returns ENAMETOOLONG if an entire path name exceeded {PATH_MAX} cha
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..4"
 
 nx=`dirgen_max`

--- a/tests/mkfifo/04.t
+++ b/tests/mkfifo/04.t
@@ -7,6 +7,8 @@ desc="mkfifo returns ENOENT if a component of the path prefix does not exist"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..3"
 
 n0=`namegen`

--- a/tests/mkfifo/05.t
+++ b/tests/mkfifo/05.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
+require root
 
 echo "1..12"
 

--- a/tests/mkfifo/05.t
+++ b/tests/mkfifo/05.t
@@ -7,6 +7,8 @@ desc="mkfifo returns EACCES when search permission is denied for a component of 
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/mkfifo/06.t
+++ b/tests/mkfifo/06.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
+require root
 
 echo "1..12"
 

--- a/tests/mkfifo/06.t
+++ b/tests/mkfifo/06.t
@@ -7,6 +7,8 @@ desc="mkfifo returns EACCES when write permission is denied on the parent direct
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/mkfifo/07.t
+++ b/tests/mkfifo/07.t
@@ -7,6 +7,7 @@ desc="mkfifo returns ELOOP if too many symbolic links were encountered in transl
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 echo "1..6"
 
 n0=`namegen`

--- a/tests/mkfifo/08.t
+++ b/tests/mkfifo/08.t
@@ -7,6 +7,8 @@ desc="mkfifo returns EROFS if the named file resides on a read-only file system"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 [ "${os}:${fs}" = "FreeBSD:UFS" ] || quick_exit
 
 echo "1..7"

--- a/tests/mkfifo/09.t
+++ b/tests/mkfifo/09.t
@@ -7,6 +7,8 @@ desc="mkfifo returns EEXIST if the named file exists"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..21"
 
 n0=`namegen`

--- a/tests/mkfifo/09.t
+++ b/tests/mkfifo/09.t
@@ -12,6 +12,8 @@ echo "1..21"
 n0=`namegen`
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect EEXIST mkfifo ${n0} 0644
 	if [ "${type}" = "dir" ]; then
@@ -19,4 +21,6 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done

--- a/tests/mkfifo/10.t
+++ b/tests/mkfifo/10.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require chflags
+require ftype_fifo
 
 case "${os}:${fs}" in
 FreeBSD:ZFS)

--- a/tests/mkfifo/10.t
+++ b/tests/mkfifo/10.t
@@ -10,16 +10,7 @@ dir=`dirname $0`
 require chflags
 require ftype_fifo
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..17"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 n1=`namegen`
@@ -45,24 +36,26 @@ expect 0 mkfifo ${n0}/${n1} 0644
 expect 0 chflags ${n0} none
 expect 0 unlink ${n0}/${n1}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM mkfifo ${n0}/${n1} 0644
 	expect 0 chflags ${n0} none
 	expect 0 mkfifo ${n0}/${n1} 0644
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 mkfifo ${n0}/${n1} 0644
 	expect 0 unlink ${n0}/${n1}
 	expect 0 chflags ${n0} none
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 mkfifo ${n0}/${n1} 0644
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/mkfifo/11.t
+++ b/tests/mkfifo/11.t
@@ -7,6 +7,8 @@ desc="mkfifo returns ENOSPC if there are no free inodes on the file system on wh
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 [ "${os}:${fs}" = "FreeBSD:UFS" ] || quick_exit
 
 echo "1..3"

--- a/tests/mkfifo/12.t
+++ b/tests/mkfifo/12.t
@@ -7,6 +7,8 @@ desc="mkfifo returns EFAULT if the path argument points outside the process's al
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..2"
 
 expect EFAULT mkfifo NULL 0644

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -7,6 +7,7 @@ desc="mknod creates fifo files"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 require mknod
 
 echo "1..35"

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -37,21 +37,6 @@ expect 0 -U 0501 mknod ${n0} f 0345 0 0
 expect fifo,0244 lstat ${n0} type,mode
 expect 0 unlink ${n0}
 
-# POSIX: The FIFO's user ID shall be set to the process' effective user ID.
-# The FIFO's group ID shall be set to the group ID of the parent directory or to
-# the effective group ID of the process.
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 mknod ${n0} f 0755 0 0
-expect 65535,65535 lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 -u 65535 -g 65534 mknod ${n0} f 0755 0 0
-expect "65535,6553[45]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 mknod ${n0} f 0755 0 0
-expect "65534,6553[35]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-
 # POSIX: Upon successful completion, mknod() shall mark for update the
 # st_atime, st_ctime, and st_mtime fields of the file. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
@@ -70,6 +55,21 @@ mtime=`${fstest} stat . mtime`
 test_check $time -lt $mtime
 ctime=`${fstest} stat . ctime`
 test_check $time -lt $ctime
+expect 0 unlink ${n0}
+
+# POSIX: The FIFO's user ID shall be set to the process' effective user ID.
+# The FIFO's group ID shall be set to the group ID of the parent directory or to
+# the effective group ID of the process.
+expect 0 chown . 65535 65535
+expect 0 -u 65535 -g 65535 mknod ${n0} f 0755 0 0
+expect 65535,65535 lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+expect 0 -u 65535 -g 65534 mknod ${n0} f 0755 0 0
+expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+expect 0 chmod . 0777
+expect 0 -u 65534 -g 65533 mknod ${n0} f 0755 0 0
+expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 
 cd ${cdir}

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -42,7 +42,7 @@ expect 0 unlink ${n0}
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
 time=`${fstest} stat . ctime`
-sleep 1
+nap
 expect 0 mknod ${n0} f 0755 0 0
 atime=`${fstest} stat ${n0} atime`
 test_check $time -lt $atime

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -9,7 +9,7 @@ dir=`dirname $0`
 
 require mknod
 
-echo "1..36"
+echo "1..35"
 
 n0=`namegen`
 n1=`namegen`
@@ -41,7 +41,6 @@ expect 0 unlink ${n0}
 # st_atime, st_ctime, and st_mtime fields of the file. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
-expect 0 chown . 0 0
 time=`${fstest} stat . ctime`
 sleep 1
 expect 0 mknod ${n0} f 0755 0 0

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -60,6 +60,7 @@ expect 0 unlink ${n0}
 # POSIX: The FIFO's user ID shall be set to the process' effective user ID.
 # The FIFO's group ID shall be set to the group ID of the parent directory or to
 # the effective group ID of the process.
+push_requirement root
 expect 0 chown . 65535 65535
 expect 0 -u 65535 -g 65535 mknod ${n0} f 0755 0 0
 expect 65535,65535 lstat ${n0} uid,gid
@@ -71,6 +72,7 @@ expect 0 chmod . 0777
 expect 0 -u 65534 -g 65533 mknod ${n0} f 0755 0 0
 expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n1}

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -41,18 +41,18 @@ expect 0 unlink ${n0}
 # st_atime, st_ctime, and st_mtime fields of the file. Also, the st_ctime and
 # st_mtime fields of the directory that contains the new entry shall be marked
 # for update.
-time=`${fstest} stat . ctime`
+time=`query stat . ctime`
 nap
 expect 0 mknod ${n0} f 0755 0 0
-atime=`${fstest} stat ${n0} atime`
+atime=`query stat ${n0} atime`
 test_check $time -lt $atime
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
-mtime=`${fstest} stat . mtime`
+mtime=`query stat . mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat . ctime`
+ctime=`query stat . ctime`
 test_check $time -lt $ctime
 expect 0 unlink ${n0}
 

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -8,7 +8,6 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
-require mknod
 
 echo "1..35"
 

--- a/tests/mknod/01.t
+++ b/tests/mknod/01.t
@@ -16,10 +16,14 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR mknod ${n0}/${n1}/test b 0644 1 2
 	expect ENOTDIR mknod ${n0}/${n1}/test c 0644 1 2
 	expect ENOTDIR mknod ${n0}/${n1}/test f 0644 0 0
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/mknod/01.t
+++ b/tests/mknod/01.t
@@ -7,8 +7,6 @@ desc="mknod returns ENOTDIR if a component of the path prefix is not a directory
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require mknod
-
 echo "1..27"
 
 n0=`namegen`

--- a/tests/mknod/01.t
+++ b/tests/mknod/01.t
@@ -19,9 +19,19 @@ for type in regular fifo block char socket; do
 	push_requirement ftype_${type}
 
 	create_file ${type} ${n0}/${n1}
+
+	push_requirement ftype_block
 	expect ENOTDIR mknod ${n0}/${n1}/test b 0644 1 2
+	pop_requirement
+
+	push_requirement ftype_char
 	expect ENOTDIR mknod ${n0}/${n1}/test c 0644 1 2
+	pop_requirement
+
+	push_requirement ftype_fifo
 	expect ENOTDIR mknod ${n0}/${n1}/test f 0644 0 0
+	pop_requirement
+
 	expect 0 unlink ${n0}/${n1}
 
 	pop_requirement

--- a/tests/mknod/02.t
+++ b/tests/mknod/02.t
@@ -7,8 +7,6 @@ desc="mknod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require mknod
-
 echo "1..12"
 
 nx=`namegen_max`

--- a/tests/mknod/02.t
+++ b/tests/mknod/02.t
@@ -14,17 +14,23 @@ echo "1..12"
 nx=`namegen_max`
 nxx="${nx}x"
 
+push_requirement ftype_fifo
 expect 0 mknod ${nx} f 0644 0 0
 expect fifo,0644 stat ${nx} type,mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} f 0644 0 0
+pop_requirement
 
+push_requirement ftype_block
 expect 0 mknod ${nx} b 0644 1 2
 expect block,0644 stat ${nx} type,mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} b 0644 0 0
+pop_requirement
 
+push_requirement ftype_char
 expect 0 mknod ${nx} c 0644 1 2
 expect char,0644 stat ${nx} type,mode
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} c 0644 0 0
+pop_requirement

--- a/tests/mknod/03.t
+++ b/tests/mknod/03.t
@@ -16,19 +16,25 @@ nxx="${nx}x"
 
 mkdir -p "${nx%/*}"
 
+push_requirement ftype_fifo
 expect 0 mknod ${nx} f 0644 0 0
 expect fifo stat ${nx} type
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} f 0644 0 0
+pop_requirement
 
+push_requirement ftype_block
 expect 0 mknod ${nx} b 0644 1 2
 expect block stat ${nx} type
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} b 0644 1 2
+pop_requirement
 
+push_requirement ftype_char
 expect 0 mknod ${nx} c 0644 1 2
 expect char stat ${nx} type
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} c 0644 1 2
+pop_requirement
 
 rm -rf "${nx%%/*}"

--- a/tests/mknod/03.t
+++ b/tests/mknod/03.t
@@ -7,8 +7,6 @@ desc="mknod returns ENAMETOOLONG if an entire path name exceeded {PATH_MAX} char
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require mknod
-
 echo "1..12"
 
 nx=`dirgen_max`

--- a/tests/mknod/04.t
+++ b/tests/mknod/04.t
@@ -8,7 +8,6 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
-require mknod
 
 echo "1..3"
 

--- a/tests/mknod/04.t
+++ b/tests/mknod/04.t
@@ -7,6 +7,7 @@ desc="mknod returns ENOENT if a component of the path prefix does not exist"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 require mknod
 
 echo "1..3"

--- a/tests/mknod/05.t
+++ b/tests/mknod/05.t
@@ -7,6 +7,7 @@ desc="mknod returns EACCES when search permission is denied for a component of t
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 require mknod
 
 echo "1..12"

--- a/tests/mknod/05.t
+++ b/tests/mknod/05.t
@@ -9,6 +9,7 @@ dir=`dirname $0`
 
 require ftype_fifo
 require mknod
+require root
 
 echo "1..12"
 

--- a/tests/mknod/05.t
+++ b/tests/mknod/05.t
@@ -8,7 +8,6 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
-require mknod
 require root
 
 echo "1..12"

--- a/tests/mknod/06.t
+++ b/tests/mknod/06.t
@@ -7,6 +7,7 @@ desc="mknod returns EACCES when write permission is denied on the parent directo
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 require mknod
 
 echo "1..12"

--- a/tests/mknod/06.t
+++ b/tests/mknod/06.t
@@ -9,6 +9,7 @@ dir=`dirname $0`
 
 require ftype_fifo
 require mknod
+require root
 
 echo "1..12"
 

--- a/tests/mknod/06.t
+++ b/tests/mknod/06.t
@@ -8,7 +8,6 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
-require mknod
 require root
 
 echo "1..12"

--- a/tests/mknod/07.t
+++ b/tests/mknod/07.t
@@ -8,7 +8,6 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
-require mknod
 
 echo "1..6"
 

--- a/tests/mknod/07.t
+++ b/tests/mknod/07.t
@@ -7,6 +7,7 @@ desc="mknod returns ELOOP if too many symbolic links were encountered in transla
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 require mknod
 
 echo "1..6"

--- a/tests/mknod/08.t
+++ b/tests/mknod/08.t
@@ -17,9 +17,19 @@ for type in regular dir fifo block char socket symlink; do
 	push_requirement ftype_${type}
 
 	create_file ${type} ${n0}
+
+	push_requirement ftype_block
 	expect EEXIST mknod ${n0} b 0644 0 0
+	pop_requirement
+
+	push_requirement ftype_char
 	expect EEXIST mknod ${n0} c 0644 0 0
+	pop_requirement
+
+	push_requirement ftype_fifo
 	expect EEXIST mknod ${n0} f 0644 0 0
+	pop_requirement
+
 	if [ "${type}" = "dir" ]; then
 		expect 0 rmdir ${n0}
 	else

--- a/tests/mknod/08.t
+++ b/tests/mknod/08.t
@@ -14,6 +14,8 @@ echo "1..35"
 n0=`namegen`
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect EEXIST mknod ${n0} b 0644 0 0
 	expect EEXIST mknod ${n0} c 0644 0 0
@@ -23,4 +25,6 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done

--- a/tests/mknod/08.t
+++ b/tests/mknod/08.t
@@ -7,8 +7,6 @@ desc="mknod returns EEXIST if the named file exists"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require mknod
-
 echo "1..35"
 
 n0=`namegen`

--- a/tests/mknod/09.t
+++ b/tests/mknod/09.t
@@ -7,8 +7,8 @@ desc="mknod returns EPERM if the parent directory of the file to be created has 
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require mknod
 require chflags
+require mknod
 
 case "${os}:${fs}" in
 FreeBSD:UFS)

--- a/tests/mknod/09.t
+++ b/tests/mknod/09.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require chflags
+require ftype_fifo
 require mknod
 
 case "${os}:${fs}" in

--- a/tests/mknod/09.t
+++ b/tests/mknod/09.t
@@ -11,14 +11,7 @@ require chflags
 require ftype_fifo
 require mknod
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	echo "1..17"
-	;;
-esac
+echo "1..30"
 
 n0=`namegen`
 n1=`namegen`
@@ -44,24 +37,26 @@ expect 0 mknod ${n0}/${n1} f 0644 0 0
 expect 0 unlink ${n0}/${n1}
 expect 0 chflags ${n0} none
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM mknod ${n0}/${n1} f 0644 0 0
 	expect 0 chflags ${n0} none
 	expect 0 mknod ${n0}/${n1} f 0644 0 0
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 mknod ${n0}/${n1} f 0644 0 0
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 mknod ${n0}/${n1} f 0644 0 0
 	expect 0 unlink ${n0}/${n1}
 	expect 0 chflags ${n0} none
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/mknod/09.t
+++ b/tests/mknod/09.t
@@ -9,7 +9,6 @@ dir=`dirname $0`
 
 require chflags
 require ftype_fifo
-require mknod
 
 echo "1..30"
 

--- a/tests/mknod/10.t
+++ b/tests/mknod/10.t
@@ -8,7 +8,6 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_fifo
-require mknod
 
 echo "1..2"
 

--- a/tests/mknod/10.t
+++ b/tests/mknod/10.t
@@ -7,6 +7,7 @@ desc="mknod returns EFAULT if the path argument points outside the process's all
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
 require mknod
 
 echo "1..2"

--- a/tests/mknod/11.t
+++ b/tests/mknod/11.t
@@ -35,6 +35,8 @@ for type in c b; do
 		;;
 	esac
 
+	push_requirement ftype_${stattype}
+
 	# Create char special with old-style numbers
 	expect 0 mknod ${n0} ${type} 0755 1 2
 	expect ${stattype},0755 lstat ${n0} type,mode
@@ -76,6 +78,8 @@ for type in c b; do
 	ctime=`query stat . ctime`
 	test_check $time -lt $ctime
 	expect 0 unlink ${n0}
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/mknod/11.t
+++ b/tests/mknod/11.t
@@ -63,7 +63,7 @@ for type in c b; do
 	# for update.
 	expect 0 chown . 0 0
 	time=`${fstest} stat . ctime`
-	sleep 1
+	nap
 	expect 0 mknod ${n0} ${type} 0755 1 2
 	atime=`${fstest} stat ${n0} atime`
 	test_check $time -lt $atime

--- a/tests/mknod/11.t
+++ b/tests/mknod/11.t
@@ -7,8 +7,6 @@ desc="mknod creates device files"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require mknod
-
 case "${os}" in
 SunOS)
 	echo "1..40"

--- a/tests/mknod/11.t
+++ b/tests/mknod/11.t
@@ -62,18 +62,18 @@ for type in c b; do
 	# st_mtime fields of the directory that contains the new entry shall be marked
 	# for update.
 	expect 0 chown . 0 0
-	time=`${fstest} stat . ctime`
+	time=`query stat . ctime`
 	nap
 	expect 0 mknod ${n0} ${type} 0755 1 2
-	atime=`${fstest} stat ${n0} atime`
+	atime=`query stat ${n0} atime`
 	test_check $time -lt $atime
-	mtime=`${fstest} stat ${n0} mtime`
+	mtime=`query stat ${n0} mtime`
 	test_check $time -lt $mtime
-	ctime=`${fstest} stat ${n0} ctime`
+	ctime=`query stat ${n0} ctime`
 	test_check $time -lt $ctime
-	mtime=`${fstest} stat . mtime`
+	mtime=`query stat . mtime`
 	test_check $time -lt $mtime
-	ctime=`${fstest} stat . ctime`
+	ctime=`query stat . ctime`
 	test_check $time -lt $ctime
 	expect 0 unlink ${n0}
 done

--- a/tests/open/00.t
+++ b/tests/open/00.t
@@ -58,6 +58,7 @@ expect 0 unlink ${n0}
 # of the file shall be set to the effective user ID of the process; the group ID
 # of the file shall be set to the group ID of the file's parent directory or to
 # the effective group ID of the process [...]
+push_requirement root
 expect 0 chown . 65535 65535
 expect 0 -u 65535 -g 65535 open ${n0} O_CREAT,O_WRONLY 0644
 expect 65535,65535 lstat ${n0} uid,gid
@@ -69,6 +70,7 @@ expect 0 chmod . 0777
 expect 0 -u 65534 -g 65533 open ${n0} O_CREAT,O_WRONLY 0644
 expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
+pop_requirement
 
 # Don't update parent directory ctime/mtime if file existed.
 expect 0 create ${n0} 0644

--- a/tests/open/00.t
+++ b/tests/open/00.t
@@ -39,18 +39,18 @@ expect regular,0244 lstat ${n0} type,mode
 expect 0 unlink ${n0}
 
 # Update parent directory ctime/mtime if file didn't exist.
-time=`${fstest} stat . ctime`
+time=`query stat . ctime`
 nap
 expect 0 open ${n0} O_CREAT,O_WRONLY 0644
-atime=`${fstest} stat ${n0} atime`
+atime=`query stat ${n0} atime`
 test_check $time -lt $atime
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
-mtime=`${fstest} stat . mtime`
+mtime=`query stat . mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat . ctime`
+ctime=`query stat . ctime`
 test_check $time -lt $ctime
 expect 0 unlink ${n0}
 
@@ -72,25 +72,25 @@ expect 0 unlink ${n0}
 
 # Don't update parent directory ctime/mtime if file existed.
 expect 0 create ${n0} 0644
-dmtime=`${fstest} stat . mtime`
-dctime=`${fstest} stat . ctime`
+dmtime=`query stat . mtime`
+dctime=`query stat . ctime`
 nap
 expect 0 open ${n0} O_CREAT,O_RDONLY 0644
-mtime=`${fstest} stat . mtime`
+mtime=`query stat . mtime`
 test_check $dmtime -eq $mtime
-ctime=`${fstest} stat . ctime`
+ctime=`query stat . ctime`
 test_check $dctime -eq $ctime
 expect 0 unlink ${n0}
 
 echo test > ${n0}
 expect 5 stat ${n0} size
-mtime1=`${fstest} stat ${n0} mtime`
-ctime1=`${fstest} stat ${n0} ctime`
+mtime1=`query stat ${n0} mtime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 open ${n0} O_WRONLY,O_TRUNC
-mtime2=`${fstest} stat ${n0} mtime`
+mtime2=`query stat ${n0} mtime`
 test_check $mtime1 -lt $mtime2
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 stat ${n0} size
 expect 0 unlink ${n0}

--- a/tests/open/00.t
+++ b/tests/open/00.t
@@ -40,7 +40,7 @@ expect 0 unlink ${n0}
 
 # Update parent directory ctime/mtime if file didn't exist.
 time=`${fstest} stat . ctime`
-sleep 1
+nap
 expect 0 open ${n0} O_CREAT,O_WRONLY 0644
 atime=`${fstest} stat ${n0} atime`
 test_check $time -lt $atime
@@ -74,7 +74,7 @@ expect 0 unlink ${n0}
 expect 0 create ${n0} 0644
 dmtime=`${fstest} stat . mtime`
 dctime=`${fstest} stat . ctime`
-sleep 1
+nap
 expect 0 open ${n0} O_CREAT,O_RDONLY 0644
 mtime=`${fstest} stat . mtime`
 test_check $dmtime -eq $mtime
@@ -86,7 +86,7 @@ echo test > ${n0}
 expect 5 stat ${n0} size
 mtime1=`${fstest} stat ${n0} mtime`
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 open ${n0} O_WRONLY,O_TRUNC
 mtime2=`${fstest} stat ${n0} mtime`
 test_check $mtime1 -lt $mtime2

--- a/tests/open/00.t
+++ b/tests/open/00.t
@@ -7,7 +7,7 @@ desc="open opens (and eventually creates) a file"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-echo "1..47"
+echo "1..46"
 
 n0=`namegen`
 n1=`namegen`
@@ -39,7 +39,6 @@ expect regular,0244 lstat ${n0} type,mode
 expect 0 unlink ${n0}
 
 # Update parent directory ctime/mtime if file didn't exist.
-expect 0 chown . 0 0
 time=`${fstest} stat . ctime`
 sleep 1
 expect 0 open ${n0} O_CREAT,O_WRONLY 0644

--- a/tests/open/00.t
+++ b/tests/open/00.t
@@ -38,22 +38,6 @@ expect 0 -U 0501 open ${n0} O_CREAT,O_WRONLY 0345
 expect regular,0244 lstat ${n0} type,mode
 expect 0 unlink ${n0}
 
-# POSIX: (If O_CREAT is specified and the file doesn't exist) [...] the user ID
-# of the file shall be set to the effective user ID of the process; the group ID
-# of the file shall be set to the group ID of the file's parent directory or to
-# the effective group ID of the process [...]
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 open ${n0} O_CREAT,O_WRONLY 0644
-expect 65535,65535 lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 -u 65535 -g 65534 open ${n0} O_CREAT,O_WRONLY 0644
-expect "65535,6553[45]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 open ${n0} O_CREAT,O_WRONLY 0644
-expect "65534,6553[35]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-
 # Update parent directory ctime/mtime if file didn't exist.
 expect 0 chown . 0 0
 time=`${fstest} stat . ctime`
@@ -69,6 +53,22 @@ mtime=`${fstest} stat . mtime`
 test_check $time -lt $mtime
 ctime=`${fstest} stat . ctime`
 test_check $time -lt $ctime
+expect 0 unlink ${n0}
+
+# POSIX: (If O_CREAT is specified and the file doesn't exist) [...] the user ID
+# of the file shall be set to the effective user ID of the process; the group ID
+# of the file shall be set to the group ID of the file's parent directory or to
+# the effective group ID of the process [...]
+expect 0 chown . 65535 65535
+expect 0 -u 65535 -g 65535 open ${n0} O_CREAT,O_WRONLY 0644
+expect 65535,65535 lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+expect 0 -u 65535 -g 65534 open ${n0} O_CREAT,O_WRONLY 0644
+expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+expect 0 chmod . 0777
+expect 0 -u 65534 -g 65533 open ${n0} O_CREAT,O_WRONLY 0644
+expect "65534,6553[35]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 
 # Don't update parent directory ctime/mtime if file existed.

--- a/tests/open/01.t
+++ b/tests/open/01.t
@@ -14,9 +14,13 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR open ${n0}/${n1}/test O_RDONLY
 	expect ENOTDIR open ${n0}/${n1}/test O_CREAT 0644
 	expect 0 unlink ${n0}/${n1}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/open/05.t
+++ b/tests/open/05.t
@@ -7,6 +7,8 @@ desc="open returns EACCES when search permission is denied for a component of th
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/open/06.t
+++ b/tests/open/06.t
@@ -90,6 +90,7 @@ expect 0 -u 65534 -g 65534 unlink ${n1}
 
 # FIFO.
 
+push_requirement ftype_fifo
 expect 0 -u 65534 -g 65534 mkfifo ${n1} 0644
 
 expect 0 -u 65534 -g 65534 chmod ${n1} 0600
@@ -142,9 +143,11 @@ expect EACCES -u 65533 -g 65533 open ${n1} O_WRONLY,O_NONBLOCK
 expect EACCES -u 65533 -g 65533 open ${n1} O_RDWR
 
 expect 0 -u 65534 -g 65534 unlink ${n1}
+pop_requirement
 
 # Directory.
 
+push_requirement ftype_dir
 expect 0 -u 65534 -g 65534 mkdir ${n1} 0755
 
 expect 0 -u 65534 -g 65534 chmod ${n1} 0600
@@ -183,6 +186,7 @@ expect 0 -u 65534 -g 65534 chmod ${n1} 0770
 expect EACCES -u 65533 -g 65533 open ${n1} O_RDONLY
 
 expect 0 -u 65534 -g 65534 rmdir ${n1}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n0}

--- a/tests/open/06.t
+++ b/tests/open/06.t
@@ -7,6 +7,8 @@ desc="open returns EACCES when the required permissions (for reading and/or writ
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..144"
 
 n0=`namegen`

--- a/tests/open/07.t
+++ b/tests/open/07.t
@@ -7,6 +7,8 @@ desc="open returns EACCES when O_TRUNC is specified and write permission is deni
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..25"
 
 n0=`namegen`

--- a/tests/open/08.t
+++ b/tests/open/08.t
@@ -7,6 +7,8 @@ desc="open returns EACCES when O_CREAT is specified, the file does not exist, an
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..3"
 
 n0=`namegen`

--- a/tests/open/09.t
+++ b/tests/open/09.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..17"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 n1=`namegen`
@@ -44,24 +35,26 @@ expect 0 open ${n0}/${n1} O_RDONLY,O_CREAT 0644
 expect 0 chflags ${n0} none
 expect 0 unlink ${n0}/${n1}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM open ${n0}/${n1} O_RDONLY,O_CREAT 0644
 	expect 0 chflags ${n0} none
 	expect 0 open ${n0}/${n1} O_RDONLY,O_CREAT 0644
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 symlink test ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 open ${n0}/${n1} O_RDONLY,O_CREAT 0644
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/open/10.t
+++ b/tests/open/10.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..14"
-	;;
-FreeBSD:UFS)
-	echo "1..28"
-	;;
-*)
-	quick_exit
-esac
+echo "1..28"
 
 n0=`namegen`
 
@@ -38,8 +29,7 @@ expect 0 open ${n0} O_RDONLY,O_TRUNC
 expect 0 chflags ${n0} none
 expect 0 unlink ${n0}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM open ${n0} O_WRONLY
@@ -47,7 +37,9 @@ FreeBSD:UFS)
 	expect EPERM open ${n0} O_RDONLY,O_TRUNC
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 open ${n0} O_WRONLY
@@ -55,5 +47,4 @@ FreeBSD:UFS)
 	expect 0 open ${n0} O_RDONLY,O_TRUNC
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
-	;;
-esac
+pop_requirement

--- a/tests/open/11.t
+++ b/tests/open/11.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..12"
-	;;
-FreeBSD:UFS)
-	echo "1..24"
-	;;
-*)
-	quick_exit
-esac
+echo "1..24"
 
 n0=`namegen`
 
@@ -39,8 +30,7 @@ expect EPERM open ${n0} O_RDWR,O_APPEND,O_TRUNC
 expect 0 chflags ${n0} none
 expect 0 unlink ${n0}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_APPEND
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 open ${n0} O_WRONLY,O_APPEND
@@ -53,5 +43,4 @@ FreeBSD:UFS)
 	expect EPERM open ${n0} O_RDWR,O_APPEND,O_TRUNC
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
-	;;
-esac
+pop_requirement

--- a/tests/open/12.t
+++ b/tests/open/12.t
@@ -7,6 +7,8 @@ desc="open returns ELOOP if too many symbolic links were encountered in translat
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/open/16.t
+++ b/tests/open/16.t
@@ -5,6 +5,8 @@
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 if [ "${os}" = "FreeBSD" ]; then
 	error=EMLINK
 else

--- a/tests/open/17.t
+++ b/tests/open/17.t
@@ -7,6 +7,8 @@ desc="open returns ENXIO when O_NONBLOCK is set, the named file is a fifo, O_WRO
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_fifo
+
 echo "1..3"
 
 n0=`namegen`

--- a/tests/open/22.t
+++ b/tests/open/22.t
@@ -12,6 +12,8 @@ echo "1..21"
 n0=`namegen`
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect EEXIST open ${n0} O_CREAT,O_EXCL 0644
 	if [ "${type}" = "dir" ]; then
@@ -19,4 +21,6 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done

--- a/tests/open/24.t
+++ b/tests/open/24.t
@@ -5,6 +5,8 @@
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_socket
+
 # POSIX doesn't explicitly state the errno for open(2)'ing sockets.
 case ${os} in
 Darwin|FreeBSD)

--- a/tests/posix_fallocate/00.t
+++ b/tests/posix_fallocate/00.t
@@ -31,7 +31,7 @@ expect 0 unlink ${n0}
 # successful posix_fallocate(2) updates ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 open ${n0} O_RDWR : posix_fallocate 0 0 123
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -40,7 +40,7 @@ expect 0 unlink ${n0}
 # unsuccessful posix_fallocate(2) does not update ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EINVAL open ${n0} O_WRONLY : posix_fallocate 0 0 0
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2

--- a/tests/posix_fallocate/00.t
+++ b/tests/posix_fallocate/00.t
@@ -30,19 +30,19 @@ expect 0 unlink ${n0}
 
 # successful posix_fallocate(2) updates ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 open ${n0} O_RDWR : posix_fallocate 0 0 123
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 # unsuccessful posix_fallocate(2) does not update ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EINVAL open ${n0} O_WRONLY : posix_fallocate 0 0 0
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -67,6 +67,7 @@ expect 0 unlink ${n2}
 pop_requirement
 
 # unsuccessful link(2) does not update ctime.
+push_requirement root
 for type in regular dir fifo block char socket symlink; do
 	push_requirement ftype_${type}
 
@@ -84,6 +85,7 @@ for type in regular dir fifo block char socket symlink; do
 
 	pop_requirement
 done
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n3}

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -19,6 +19,8 @@ cdir=`pwd`
 cd ${n3}
 
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0} 0644
 	expect ${type},0644,1 lstat ${n0} type,mode,nlink
 	inode=`query lstat ${n0} inode`
@@ -34,6 +36,8 @@ for type in regular fifo block char socket; do
 	expect ${type},${inode},0644,2 lstat ${n2} type,inode,mode,nlink
 	expect 0 unlink ${n0}
 	expect 0 unlink ${n2}
+
+	pop_requirement
 done
 
 expect 0 mkdir ${n0} 0755
@@ -60,6 +64,8 @@ expect 0 unlink ${n2}
 
 # unsuccessful link(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	ctime1=`query lstat ${n0} ctime`
 	nap
@@ -71,6 +77,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -62,7 +62,7 @@ expect 0 unlink ${n2}
 for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
 	ctime1=`${fstest} lstat ${n0} ctime`
-	sleep 1
+	nap
 	expect EACCES -u 65534 rename ${n0} ${n1}
 	ctime2=`${fstest} lstat ${n0} ctime`
 	test_check $ctime1 -eq $ctime2

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -21,7 +21,7 @@ cd ${n3}
 for type in regular fifo block char socket; do
 	create_file ${type} ${n0} 0644
 	expect ${type},0644,1 lstat ${n0} type,mode,nlink
-	inode=`${fstest} lstat ${n0} inode`
+	inode=`query lstat ${n0} inode`
 	expect 0 rename ${n0} ${n1}
 	expect ENOENT lstat ${n0} type,mode,nlink
 	expect ${type},${inode},0644,1 lstat ${n1} type,inode,mode,nlink
@@ -38,17 +38,17 @@ done
 
 expect 0 mkdir ${n0} 0755
 expect dir,0755 lstat ${n0} type,mode
-inode=`${fstest} lstat ${n0} inode`
+inode=`query lstat ${n0} inode`
 expect 0 rename ${n0} ${n1}
 expect ENOENT lstat ${n0} type,mode
 expect dir,${inode},0755 lstat ${n1} type,inode,mode
 expect 0 rmdir ${n1}
 
 expect 0 create ${n0} 0644
-rinode=`${fstest} lstat ${n0} inode`
+rinode=`query lstat ${n0} inode`
 expect regular,0644 lstat ${n0} type,mode
 expect 0 symlink ${n0} ${n1}
-sinode=`${fstest} lstat ${n1} inode`
+sinode=`query lstat ${n1} inode`
 expect regular,${rinode},0644 stat ${n1} type,inode,mode
 expect symlink,${sinode} lstat ${n1} type,inode
 expect 0 rename ${n1} ${n2}
@@ -61,10 +61,10 @@ expect 0 unlink ${n2}
 # unsuccessful link(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${n0}
-	ctime1=`${fstest} lstat ${n0} ctime`
+	ctime1=`query lstat ${n0} ctime`
 	nap
 	expect EACCES -u 65534 rename ${n0} ${n1}
-	ctime2=`${fstest} lstat ${n0} ctime`
+	ctime2=`query lstat ${n0} ctime`
 	test_check $ctime1 -eq $ctime2
 	if [ "${type}" = "dir" ]; then
 		expect 0 rmdir ${n0}

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -48,6 +48,7 @@ expect ENOENT lstat ${n0} type,mode
 expect dir,${inode},0755 lstat ${n1} type,inode,mode
 expect 0 rmdir ${n1}
 
+push_requirement ftype_symlink
 expect 0 create ${n0} 0644
 rinode=`query lstat ${n0} inode`
 expect regular,0644 lstat ${n0} type,mode
@@ -61,6 +62,7 @@ expect ENOENT lstat ${n1} type,mode
 expect symlink,${sinode} lstat ${n2} type,inode
 expect 0 unlink ${n0}
 expect 0 unlink ${n2}
+pop_requirement
 
 # unsuccessful link(2) does not update ctime.
 for type in regular dir fifo block char socket symlink; do

--- a/tests/rename/00.t
+++ b/tests/rename/00.t
@@ -18,6 +18,7 @@ expect 0 mkdir ${n3} 0755
 cdir=`pwd`
 cd ${n3}
 
+push_requirement link
 for type in regular fifo block char socket; do
 	push_requirement ftype_${type}
 
@@ -39,6 +40,7 @@ for type in regular fifo block char socket; do
 
 	pop_requirement
 done
+pop_requirement
 
 expect 0 mkdir ${n0} 0755
 expect dir,0755 lstat ${n0} type,mode

--- a/tests/rename/04.t
+++ b/tests/rename/04.t
@@ -7,6 +7,8 @@ desc="rename returns EACCES when a component of either path prefix denies search
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..18"
 
 n0=`namegen`

--- a/tests/rename/05.t
+++ b/tests/rename/05.t
@@ -7,6 +7,8 @@ desc="rename returns EACCES when the requested link requires writing in a direct
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..17"
 
 n0=`namegen`

--- a/tests/rename/06.t
+++ b/tests/rename/06.t
@@ -26,6 +26,8 @@ n0=`namegen`
 n1=`namegen`
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	if [ "${type}" != "symlink" ]; then
 		create_file ${type} ${n0}
 		for flag in ${flags}; do
@@ -59,4 +61,6 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done

--- a/tests/rename/07.t
+++ b/tests/rename/07.t
@@ -31,6 +31,8 @@ n2=`namegen`
 expect 0 mkdir ${n0} 0755
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	for flag in ${flags1}; do
 		expect 0 chflags ${n0} ${flag}
@@ -46,9 +48,13 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}/${n1}
 	fi
+
+	pop_requirement
 done
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	for flag in ${flags2}; do
 		expect 0 chflags ${n0} ${flag}
@@ -62,6 +68,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}/${n1}
 	fi
+
+	pop_requirement
 done
 
 expect 0 rmdir ${n0}

--- a/tests/rename/08.t
+++ b/tests/rename/08.t
@@ -31,6 +31,8 @@ n2=`namegen`
 expect 0 mkdir ${n0} 0755
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n1}
 	for flag in ${flags1}; do
 		expect 0 chflags ${n0} ${flag}
@@ -43,9 +45,13 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n1}
 	for flag in ${flags2}; do
 		expect 0 chflags ${n0} ${flag}
@@ -59,6 +65,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}
 	fi
+
+	pop_requirement
 done
 
 expect 0 rmdir ${n0}

--- a/tests/rename/09.t
+++ b/tests/rename/09.t
@@ -7,6 +7,8 @@ desc="rename returns EACCES or EPERM if the directory containing 'from' is marke
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..2353"
 
 n0=`namegen`

--- a/tests/rename/09.t
+++ b/tests/rename/09.t
@@ -27,12 +27,16 @@ expect 0 mkdir ${n1} 0755
 expect 0 chown ${n1} 65534 65534
 
 for type2 in regular fifo block char socket symlink; do
+	push_requirement ftype_${type2}
+
 	# User owns both: the source sticky directory and the source file.
 	expect 0 chown ${n0} 65534 65534
 	create_file ${type2} ${n0}/${n2} 65534 65534
 	inode=`query lstat ${n0}/${n2} inode`
 
 	for type3 in none regular fifo block char socket symlink; do
+		push_requirement ftype_${type3}
+
 		create_file ${type3} ${n1}/${n3} 65534 65534
 		expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 		expect ENOENT lstat ${n0}/${n2} inode
@@ -40,6 +44,8 @@ for type2 in regular fifo block char socket symlink; do
 		expect 0 -u 65534 -g 65534 rename ${n1}/${n3} ${n0}/${n2}
 		expect ${inode} lstat ${n0}/${n2} inode
 		expect ENOENT lstat ${n1}/${n3} inode
+
+		pop_requirement
 	done
 
 	expect 0 unlink ${n0}/${n2}
@@ -51,6 +57,8 @@ for type2 in regular fifo block char socket symlink; do
 		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in none regular fifo block char socket symlink; do
+			push_requirement ftype_${type3}
+
 			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
@@ -58,6 +66,8 @@ for type2 in regular fifo block char socket symlink; do
 			expect 0 -u 65534 -g 65534 rename ${n1}/${n3} ${n0}/${n2}
 			expect ${inode} lstat ${n0}/${n2} inode
 			expect ENOENT lstat ${n1}/${n3} inode
+
+			pop_requirement
 		done
 
 		expect 0 unlink ${n0}/${n2}
@@ -70,6 +80,8 @@ for type2 in regular fifo block char socket symlink; do
 		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in none regular fifo block char socket symlink; do
+			push_requirement ftype_${type3}
+
 			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
@@ -77,6 +89,8 @@ for type2 in regular fifo block char socket symlink; do
 			expect 0 -u 65534 -g 65534 rename ${n1}/${n3} ${n0}/${n2}
 			expect ${inode} lstat ${n0}/${n2} inode
 			expect ENOENT lstat ${n1}/${n3} inode
+
+			pop_requirement
 		done
 
 		expect 0 unlink ${n0}/${n2}
@@ -89,6 +103,8 @@ for type2 in regular fifo block char socket symlink; do
 		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in none regular fifo block char socket symlink; do
+			push_requirement ftype_${type3}
+
 			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ${inode},${id},${id} lstat ${n0}/${n2} inode,uid,gid
@@ -96,10 +112,14 @@ for type2 in regular fifo block char socket symlink; do
 				expect 65534,65534 lstat ${n1}/${n3} uid,gid
 				expect 0 unlink ${n1}/${n3}
 			fi
+
+			pop_requirement
 		done
 
 		expect 0 unlink ${n0}/${n2}
 	done
+
+	pop_requirement
 done
 
 # User owns both: the source sticky directory and the source directory.

--- a/tests/rename/09.t
+++ b/tests/rename/09.t
@@ -30,7 +30,7 @@ for type2 in regular fifo block char socket symlink; do
 	# User owns both: the source sticky directory and the source file.
 	expect 0 chown ${n0} 65534 65534
 	create_file ${type2} ${n0}/${n2} 65534 65534
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	for type3 in none regular fifo block char socket symlink; do
 		create_file ${type3} ${n1}/${n3} 65534 65534
@@ -48,7 +48,7 @@ for type2 in regular fifo block char socket symlink; do
 	for id in 0 65533; do
 		expect 0 chown ${n0} 65534 65534
 		create_file ${type2} ${n0}/${n2} ${id} ${id}
-		inode=`${fstest} lstat ${n0}/${n2} inode`
+		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in none regular fifo block char socket symlink; do
 			create_file ${type3} ${n1}/${n3} 65534 65534
@@ -67,7 +67,7 @@ for type2 in regular fifo block char socket symlink; do
 	for id in 0 65533; do
 		expect 0 chown ${n0} ${id} ${id}
 		create_file ${type2} ${n0}/${n2} 65534 65534
-		inode=`${fstest} lstat ${n0}/${n2} inode`
+		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in none regular fifo block char socket symlink; do
 			create_file ${type3} ${n1}/${n3} 65534 65534
@@ -86,7 +86,7 @@ for type2 in regular fifo block char socket symlink; do
 	for id in 0 65533; do
 		expect 0 chown ${n0} ${id} ${id}
 		create_file ${type2} ${n0}/${n2} ${id} ${id}
-		inode=`${fstest} lstat ${n0}/${n2} inode`
+		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in none regular fifo block char socket symlink; do
 			create_file ${type3} ${n1}/${n3} 65534 65534
@@ -105,7 +105,7 @@ done
 # User owns both: the source sticky directory and the source directory.
 expect 0 chown ${n0} 65534 65534
 create_file dir ${n0}/${n2} 65534 65534
-inode=`${fstest} lstat ${n0}/${n2} inode`
+inode=`query lstat ${n0}/${n2} inode`
 
 expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 expect ENOENT lstat ${n0}/${n2} type
@@ -125,7 +125,7 @@ expect 0 rmdir ${n1}/${n3}
 for id in 0 65533; do
 	expect 0 chown ${n0} 65534 65534
 	create_file dir ${n0}/${n2} ${id} ${id}
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 	expect ${inode},${id},${id} lstat ${n0}/${n2} inode,uid,gid
@@ -153,7 +153,7 @@ done
 for id in 0 65533; do
 	expect 0 chown ${n0} ${id} ${id}
 	create_file dir ${n0}/${n2} 65534 65534
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 	expect ENOENT lstat ${n0}/${n2} type
@@ -171,7 +171,7 @@ done
 for id in 0 65533; do
 	expect 0 chown ${n0} ${id} ${id}
 	create_file dir ${n0}/${n2} ${id} ${id}
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 	expect ${inode},${id},${id} lstat ${n0}/${n2} inode,uid,gid

--- a/tests/rename/10.t
+++ b/tests/rename/10.t
@@ -7,6 +7,8 @@ desc="rename returns EACCES or EPERM if the file pointed at by the 'to' argument
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..2099"
 
 n0=`namegen`

--- a/tests/rename/10.t
+++ b/tests/rename/10.t
@@ -26,12 +26,16 @@ expect 0 mkdir ${n1} 0755
 expect 0 chmod ${n1} 01777
 
 for type2 in regular fifo block char socket symlink; do
+	push_requirement ftype_${type2}
+
 	# User owns both: the sticky directory and the destination file.
 	expect 0 chown ${n1} 65534 65534
 	create_file ${type2} ${n0}/${n2} 65534 65534
 	inode=`query lstat ${n0}/${n2} inode`
 
 	for type3 in regular fifo block char socket symlink; do
+		push_requirement ftype_${type3}
+
 		create_file ${type3} ${n1}/${n3} 65534 65534
 		expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 		expect ENOENT lstat ${n0}/${n2} inode
@@ -39,6 +43,8 @@ for type2 in regular fifo block char socket symlink; do
 		expect 0 -u 65534 -g 65534 rename ${n1}/${n3} ${n0}/${n2}
 		expect ${inode} lstat ${n0}/${n2} inode
 		expect ENOENT lstat ${n1}/${n3} inode
+
+		pop_requirement
 	done
 
 	expect 0 unlink ${n0}/${n2}
@@ -50,6 +56,8 @@ for type2 in regular fifo block char socket symlink; do
 		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in regular fifo block char socket symlink; do
+			push_requirement ftype_${type3}
+
 			create_file ${type3} ${n1}/${n3} ${id} ${id}
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
@@ -57,6 +65,8 @@ for type2 in regular fifo block char socket symlink; do
 			expect 0 -u 65534 -g 65534 rename ${n1}/${n3} ${n0}/${n2}
 			expect ${inode} lstat ${n0}/${n2} inode
 			expect ENOENT lstat ${n1}/${n3} inode
+
+			pop_requirement
 		done
 
 		expect 0 unlink ${n0}/${n2}
@@ -69,6 +79,8 @@ for type2 in regular fifo block char socket symlink; do
 		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in regular fifo block char socket symlink; do
+			push_requirement ftype_${type3}
+
 			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
@@ -76,6 +88,8 @@ for type2 in regular fifo block char socket symlink; do
 			expect 0 -u 65534 -g 65534 rename ${n1}/${n3} ${n0}/${n2}
 			expect ${inode} lstat ${n0}/${n2} inode
 			expect ENOENT lstat ${n1}/${n3} inode
+
+			pop_requirement
 		done
 
 		expect 0 unlink ${n0}/${n2}
@@ -88,15 +102,21 @@ for type2 in regular fifo block char socket symlink; do
 		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in regular fifo block char socket symlink; do
+			push_requirement ftype_${type3}
+
 			create_file ${type3} ${n1}/${n3} ${id} ${id}
 			expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ${inode} lstat ${n0}/${n2} inode
 			expect ${id},${id} lstat ${n1}/${n3} uid,gid
 			expect 0 unlink ${n1}/${n3}
+
+			pop_requirement
 		done
 
 		expect 0 unlink ${n0}/${n2}
 	done
+
+	pop_requirement
 done
 
 # User owns both: the sticky directory and the destination directory.

--- a/tests/rename/10.t
+++ b/tests/rename/10.t
@@ -29,7 +29,7 @@ for type2 in regular fifo block char socket symlink; do
 	# User owns both: the sticky directory and the destination file.
 	expect 0 chown ${n1} 65534 65534
 	create_file ${type2} ${n0}/${n2} 65534 65534
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	for type3 in regular fifo block char socket symlink; do
 		create_file ${type3} ${n1}/${n3} 65534 65534
@@ -47,7 +47,7 @@ for type2 in regular fifo block char socket symlink; do
 	for id in 0 65533; do
 		expect 0 chown ${n1} 65534 65534
 		create_file ${type2} ${n0}/${n2} 65534 65534
-		inode=`${fstest} lstat ${n0}/${n2} inode`
+		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in regular fifo block char socket symlink; do
 			create_file ${type3} ${n1}/${n3} ${id} ${id}
@@ -66,7 +66,7 @@ for type2 in regular fifo block char socket symlink; do
 	for id in 0 65533; do
 		expect 0 chown ${n1} ${id} ${id}
 		create_file ${type2} ${n0}/${n2} 65534 65534
-		inode=`${fstest} lstat ${n0}/${n2} inode`
+		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in regular fifo block char socket symlink; do
 			create_file ${type3} ${n1}/${n3} 65534 65534
@@ -85,7 +85,7 @@ for type2 in regular fifo block char socket symlink; do
 	for id in 0 65533; do
 		expect 0 chown ${n1} ${id} ${id}
 		create_file ${type2} ${n0}/${n2} 65534 65534
-		inode=`${fstest} lstat ${n0}/${n2} inode`
+		inode=`query lstat ${n0}/${n2} inode`
 
 		for type3 in regular fifo block char socket symlink; do
 			create_file ${type3} ${n1}/${n3} ${id} ${id}
@@ -102,7 +102,7 @@ done
 # User owns both: the sticky directory and the destination directory.
 expect 0 chown ${n1} 65534 65534
 expect 0 -u 65534 -g 65534 mkdir ${n0}/${n2} 0755
-inode=`${fstest} lstat ${n0}/${n2} inode`
+inode=`query lstat ${n0}/${n2} inode`
 
 expect 0 -u 65534 -g 65534 mkdir ${n1}/${n3} 0755
 expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
@@ -114,7 +114,7 @@ expect 0 rmdir ${n1}/${n3}
 for id in 0 65533; do
 	expect 0 chown ${n1} 65534 65534
 	expect 0 -u 65534 -g 65534 mkdir ${n0}/${n2} 0755
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	expect 0 -u ${id} -g ${id} mkdir ${n1}/${n3} 0755
 	expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
@@ -127,7 +127,7 @@ done
 for id in 0 65533; do
 	expect 0 chown ${n1} ${id} ${id}
 	expect 0 -u 65534 -g 65534 mkdir ${n0}/${n2} 0755
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	expect 0 -u 65534 -g 65534 mkdir ${n1}/${n3} 0755
 	expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
@@ -140,7 +140,7 @@ done
 for id in 0 65533; do
 	expect 0 chown ${n1} ${id} ${id}
 	expect 0 -u 65534 -g 65534 mkdir ${n0}/${n2} 0755
-	inode=`${fstest} lstat ${n0}/${n2} inode`
+	inode=`query lstat ${n0}/${n2} inode`
 
 	expect 0 -u ${id} -g ${id} mkdir ${n1}/${n3} 0755
 	expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}

--- a/tests/rename/11.t
+++ b/tests/rename/11.t
@@ -7,6 +7,8 @@ desc="rename returns ELOOP if too many symbolic links were encountered in transl
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/rename/12.t
+++ b/tests/rename/12.t
@@ -15,11 +15,15 @@ n2=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect ENOTDIR rename ${n0}/${n1}/test ${n0}/${n2}
 	create_file ${type} ${n0}/${n2}
 	expect ENOTDIR link ${n0}/${n2} ${n0}/${n1}/test
 	expect 0 unlink ${n0}/${n1}
 	expect 0 unlink ${n0}/${n2}
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/rename/13.t
+++ b/tests/rename/13.t
@@ -15,11 +15,15 @@ n1=`namegen`
 expect 0 mkdir ${n0} 0755
 
 for type in regular fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n1}
 	expect ENOTDIR rename ${n0} ${n1}
 	expect dir lstat ${n0} type
 	expect ${type} lstat ${n1} type
 	expect 0 unlink ${n1}
+
+	pop_requirement
 done
 
 expect 0 rmdir ${n0}

--- a/tests/rename/14.t
+++ b/tests/rename/14.t
@@ -15,11 +15,15 @@ n1=`namegen`
 expect 0 mkdir ${n0} 0755
 
 for type in regular fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n1}
 	expect EISDIR rename ${n1} ${n0}
 	expect dir lstat ${n0} type
 	expect ${type} lstat ${n1} type
 	expect 0 unlink ${n1}
+
+	pop_requirement
 done
 
 expect 0 rmdir ${n0}

--- a/tests/rename/15.t
+++ b/tests/rename/15.t
@@ -21,6 +21,8 @@ newfs /dev/md${n} >/dev/null || exit
 mount /dev/md${n} ${n0} || exit
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect EXDEV rename ${n0}/${n1} ${n2}
 	if [ "${type}" = "dir" ]; then
@@ -28,6 +30,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}/${n1}
 	fi
+
+	pop_requirement
 done
 
 umount /dev/md${n}

--- a/tests/rename/20.t
+++ b/tests/rename/20.t
@@ -17,6 +17,8 @@ expect 0 mkdir ${n0} 0755
 expect 0 mkdir ${n1} 0755
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n1}/${n2}
 	expect "EEXIST|ENOTEMPTY" rename ${n0} ${n1}
 	if [ "${type}" = "dir" ]; then
@@ -24,6 +26,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n1}/${n2}
 	fi
+
+	pop_requirement
 done
 
 expect 0 rmdir ${n1}

--- a/tests/rename/21.t
+++ b/tests/rename/21.t
@@ -7,6 +7,8 @@ desc="write access to subdirectory is required to move it to another directory"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..16"
 
 n0=`namegen`

--- a/tests/rename/22.t
+++ b/tests/rename/22.t
@@ -22,10 +22,10 @@ cd ${parent}
 # successful rename(2) updates ctime.
 for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${src}
-	ctime1=`${fstest} lstat ${src} ctime`
+	ctime1=`query lstat ${src} ctime`
 	nap
 	expect 0 rename ${src} ${dst}
-	ctime2=`${fstest} lstat ${dst} ctime`
+	ctime2=`query lstat ${dst} ctime`
 	test_check $ctime1 -lt $ctime2
 	if [ "${type}" = "dir" ]; then
 		expect 0 rmdir ${dst}

--- a/tests/rename/22.t
+++ b/tests/rename/22.t
@@ -23,7 +23,7 @@ cd ${parent}
 for type in regular dir fifo block char socket symlink; do
 	create_file ${type} ${src}
 	ctime1=`${fstest} lstat ${src} ctime`
-	sleep 1
+	nap
 	expect 0 rename ${src} ${dst}
 	ctime2=`${fstest} lstat ${dst} ctime`
 	test_check $ctime1 -lt $ctime2

--- a/tests/rename/22.t
+++ b/tests/rename/22.t
@@ -21,6 +21,8 @@ cd ${parent}
 
 # successful rename(2) updates ctime.
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${src}
 	ctime1=`query lstat ${src} ctime`
 	nap
@@ -32,6 +34,8 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${dst}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/rename/23.t
+++ b/tests/rename/23.t
@@ -23,7 +23,7 @@ for type in regular fifo block char socket; do
 	create_file ${type} ${dst}
 	expect 0 link ${dst} ${dstlnk}
 	ctime1=`${fstest} lstat ${dstlnk} ctime`
-	sleep 1
+	nap
 
 	expect 0 rename ${src} ${dst}
 

--- a/tests/rename/23.t
+++ b/tests/rename/23.t
@@ -7,6 +7,8 @@ desc="rename succeeds when to is multiply linked"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require link
+
 echo "1..42"
 
 src=`namegen`

--- a/tests/rename/23.t
+++ b/tests/rename/23.t
@@ -19,6 +19,8 @@ cdir=`pwd`
 cd ${parent}
 
 for type in regular fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${src}
 	create_file ${type} ${dst}
 	expect 0 link ${dst} ${dstlnk}
@@ -34,6 +36,8 @@ for type in regular fifo block char socket; do
 
 	expect 0 unlink ${dst}
 	expect 0 unlink ${dstlnk}
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/rename/23.t
+++ b/tests/rename/23.t
@@ -22,14 +22,14 @@ for type in regular fifo block char socket; do
 	create_file ${type} ${src}
 	create_file ${type} ${dst}
 	expect 0 link ${dst} ${dstlnk}
-	ctime1=`${fstest} lstat ${dstlnk} ctime`
+	ctime1=`query lstat ${dstlnk} ctime`
 	nap
 
 	expect 0 rename ${src} ${dst}
 
 	# destination inode should have reduced nlink and updated ctime
 	expect ${type},1 lstat ${dstlnk} type,nlink
-	ctime2=`${fstest} lstat ${dstlnk} ctime`
+	ctime2=`query lstat ${dstlnk} ctime`
 	test_check $ctime1 -lt $ctime2
 
 	expect 0 unlink ${dst}

--- a/tests/rename/24.t
+++ b/tests/rename/24.t
@@ -21,7 +21,7 @@ cdir=`pwd`
 # Initial conditions
 expect 3 lstat ${src_parent} nlink
 expect 2 lstat ${dst_parent} nlink
-dotdot_inode=`${fstest} lstat ${src_parent} inode`
+dotdot_inode=`query lstat ${src_parent} inode`
 expect ${dotdot_inode} lstat ${src_parent}/${src}/.. inode
 
 expect 0 rename ${src_parent}/${src} ${dst_parent}/${dst}
@@ -29,7 +29,7 @@ expect 0 rename ${src_parent}/${src} ${dst_parent}/${dst}
 # The .. link and parents' nlinks values should be updated
 expect 2 lstat ${src_parent} nlink
 expect 3 lstat ${dst_parent} nlink
-dotdot_inode=`${fstest} lstat ${dst_parent} inode`
+dotdot_inode=`query lstat ${dst_parent} inode`
 expect ${dotdot_inode} lstat ${dst_parent}/${dst}/.. inode
 
 cd ${cdir}

--- a/tests/rmdir/00.t
+++ b/tests/rmdir/00.t
@@ -20,7 +20,7 @@ expect ENOENT lstat ${n0} type
 expect 0 mkdir ${n0} 0755
 expect 0 mkdir ${n0}/${n1} 0755
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 rmdir ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime

--- a/tests/rmdir/00.t
+++ b/tests/rmdir/00.t
@@ -19,11 +19,11 @@ expect ENOENT lstat ${n0} type
 
 expect 0 mkdir ${n0} 0755
 expect 0 mkdir ${n0}/${n1} 0755
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 rmdir ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}

--- a/tests/rmdir/01.t
+++ b/tests/rmdir/01.t
@@ -22,10 +22,14 @@ expect 0 create ${n0} 0644
 expect ENOTDIR rmdir ${n0}
 expect 0 unlink ${n0}
 
+push_requirement ftype_symlink
 expect 0 symlink ${n1} ${n0}
 expect ENOTDIR rmdir ${n0}
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_fifo
 expect 0 mkfifo ${n0} 0644
 expect ENOTDIR rmdir ${n0}
 expect 0 unlink ${n0}
+pop_requirement

--- a/tests/rmdir/05.t
+++ b/tests/rmdir/05.t
@@ -7,6 +7,8 @@ desc="rmdir returns ELOOP if too many symbolic links were encountered in transla
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/rmdir/06.t
+++ b/tests/rmdir/06.t
@@ -14,6 +14,8 @@ n1=`namegen`
 
 expect 0 mkdir ${n0} 0755
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}/${n1}
 	expect "EEXIST|ENOTEMPTY" rmdir ${n0}
 	if [ "${type}" = "dir" ]; then
@@ -21,5 +23,7 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}/${n1}
 	fi
+
+	pop_requirement
 done
 expect 0 rmdir ${n0}

--- a/tests/rmdir/07.t
+++ b/tests/rmdir/07.t
@@ -7,6 +7,8 @@ desc="rmdir returns EACCES when search permission is denied for a component of t
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/rmdir/08.t
+++ b/tests/rmdir/08.t
@@ -7,6 +7,8 @@ desc="rmdir returns EACCES when write permission is denied on the directory cont
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/rmdir/09.t
+++ b/tests/rmdir/09.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..15"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 
@@ -43,24 +34,26 @@ expect 0 chflags ${n0} none
 todo FreeBSD:ZFS "Removing a directory protected by SF_APPEND should return EPERM."
 expect 0 rmdir ${n0}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 mkdir ${n0} 0755
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM rmdir ${n0}
 	expect 0 chflags ${n0} none
 	expect 0 rmdir ${n0}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 mkdir ${n0} 0755
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect EPERM rmdir ${n0}
 	expect 0 chflags ${n0} none
 	expect 0 rmdir ${n0}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 mkdir ${n0} 0755
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM rmdir ${n0}
 	expect 0 chflags ${n0} none
 	expect 0 rmdir ${n0}
-	;;
-esac
+pop_requirement

--- a/tests/rmdir/10.t
+++ b/tests/rmdir/10.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..16"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 n1=`namegen`
@@ -44,25 +35,27 @@ expect 0 chflags ${n0} none
 todo FreeBSD:ZFS "Removing an entry from directory protected by SF_APPEND should return EPERM."
 expect 0 rmdir ${n0}/${n1}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 mkdir ${n0}/${n1} 0755
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM rmdir ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 rmdir ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 mkdir ${n0}/${n1} 0755
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 rmdir ${n0}/${n1}
 	expect 0 chflags ${n0} none
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 mkdir ${n0}/${n1} 0755
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM rmdir ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 rmdir ${n0}/${n1}
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/rmdir/11.t
+++ b/tests/rmdir/11.t
@@ -7,6 +7,8 @@ desc="rmdir returns EACCES or EPERM if the directory containing the directory to
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..47"
 
 n0=`namegen`

--- a/tests/symlink/00.t
+++ b/tests/symlink/00.t
@@ -7,6 +7,8 @@ desc="symlink creates symbolic links"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..14"
 
 n0=`namegen`

--- a/tests/symlink/00.t
+++ b/tests/symlink/00.t
@@ -22,12 +22,12 @@ expect ENOENT stat ${n1} type,mode
 expect 0 unlink ${n1}
 
 expect 0 mkdir ${n0} 0755
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 symlink test ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 unlink ${n0}/${n1}
 expect 0 rmdir ${n0}

--- a/tests/symlink/00.t
+++ b/tests/symlink/00.t
@@ -23,7 +23,7 @@ expect 0 unlink ${n1}
 
 expect 0 mkdir ${n0} 0755
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 symlink test ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime

--- a/tests/symlink/01.t
+++ b/tests/symlink/01.t
@@ -7,6 +7,8 @@ desc="symlink returns ENOTDIR if a component of the name2 path prefix is not a d
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..5"
 
 n0=`namegen`

--- a/tests/symlink/02.t
+++ b/tests/symlink/02.t
@@ -7,6 +7,8 @@ desc="symlink returns ENAMETOOLONG if a component of the name2 pathname exceeded
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..7"
 
 n0=`namegen`

--- a/tests/symlink/03.t
+++ b/tests/symlink/03.t
@@ -7,6 +7,8 @@ desc="symlink returns ENAMETOOLONG if an entire length of either path name excee
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/symlink/04.t
+++ b/tests/symlink/04.t
@@ -7,6 +7,8 @@ desc="symlink returns ENOENT if a component of the name2 path prefix does not ex
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..3"
 
 n0=`namegen`

--- a/tests/symlink/05.t
+++ b/tests/symlink/05.t
@@ -7,6 +7,8 @@ desc="symlink returns EACCES when a component of the name2 path prefix denies se
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/symlink/05.t
+++ b/tests/symlink/05.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_symlink
+require root
 
 echo "1..12"
 

--- a/tests/symlink/06.t
+++ b/tests/symlink/06.t
@@ -7,6 +7,8 @@ desc="symlink returns EACCES if the parent directory of the file to be created d
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..12"
 
 n0=`namegen`

--- a/tests/symlink/06.t
+++ b/tests/symlink/06.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require ftype_symlink
+require root
 
 echo "1..12"
 

--- a/tests/symlink/07.t
+++ b/tests/symlink/07.t
@@ -7,6 +7,8 @@ desc="symlink returns ELOOP if too many symbolic links were encountered in trans
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/symlink/08.t
+++ b/tests/symlink/08.t
@@ -7,6 +7,8 @@ desc="symlink returns EEXIST if the name2 argument already exists"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..21"
 
 n0=`namegen`

--- a/tests/symlink/08.t
+++ b/tests/symlink/08.t
@@ -12,6 +12,8 @@ echo "1..21"
 n0=`namegen`
 
 for type in regular dir fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect EEXIST symlink test ${n0}
 	if [ "${type}" = "dir" ]; then
@@ -19,4 +21,6 @@ for type in regular dir fifo block char socket symlink; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done

--- a/tests/symlink/09.t
+++ b/tests/symlink/09.t
@@ -10,16 +10,7 @@ dir=`dirname $0`
 require chflags
 require ftype_symlink
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..17"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 n1=`namegen`
@@ -45,24 +36,26 @@ expect 0 symlink test ${n0}/${n1}
 expect 0 chflags ${n0} none
 expect 0 unlink ${n0}/${n1}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM symlink test ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 symlink test ${n0}/${n1}
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 symlink test ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 chflags ${n0} UF_APPEND
 	expect 0 symlink test ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/symlink/09.t
+++ b/tests/symlink/09.t
@@ -8,6 +8,7 @@ dir=`dirname $0`
 . ${dir}/../misc.sh
 
 require chflags
+require ftype_symlink
 
 case "${os}:${fs}" in
 FreeBSD:ZFS)

--- a/tests/symlink/10.t
+++ b/tests/symlink/10.t
@@ -7,6 +7,8 @@ desc="symlink returns EROFS if the file name2 would reside on a read-only file s
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 [ "${os}:${fs}" = "FreeBSD:UFS" ] || quick_exit
 
 echo "1..7"

--- a/tests/symlink/11.t
+++ b/tests/symlink/11.t
@@ -7,6 +7,8 @@ desc="symlink returns ENOSPC if there are no free inodes on the file system on w
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 [ "${os}:${fs}" = "FreeBSD:UFS" ] || quick_exit
 
 echo "1..3"

--- a/tests/symlink/12.t
+++ b/tests/symlink/12.t
@@ -7,6 +7,8 @@ desc="symlink returns EFAULT if one of the pathnames specified is outside the pr
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/truncate/00.t
+++ b/tests/truncate/00.t
@@ -32,19 +32,19 @@ expect 0 unlink ${n0}
 
 # successful truncate(2) updates ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 truncate ${n0} 123
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 # unsuccessful truncate(2) does not update ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EACCES -u 65534 truncate ${n0} 123
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 

--- a/tests/truncate/00.t
+++ b/tests/truncate/00.t
@@ -40,6 +40,7 @@ test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 # unsuccessful truncate(2) does not update ctime.
+push_requirement root
 expect 0 create ${n0} 0644
 ctime1=`query stat ${n0} ctime`
 nap
@@ -47,6 +48,7 @@ expect EACCES -u 65534 truncate ${n0} 123
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n1}

--- a/tests/truncate/00.t
+++ b/tests/truncate/00.t
@@ -33,7 +33,7 @@ expect 0 unlink ${n0}
 # successful truncate(2) updates ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 truncate ${n0} 123
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -42,7 +42,7 @@ expect 0 unlink ${n0}
 # unsuccessful truncate(2) does not update ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EACCES -u 65534 truncate ${n0} 123
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2

--- a/tests/truncate/05.t
+++ b/tests/truncate/05.t
@@ -7,6 +7,8 @@ desc="truncate returns EACCES when search permission is denied for a component o
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..15"
 
 n0=`namegen`

--- a/tests/truncate/06.t
+++ b/tests/truncate/06.t
@@ -7,6 +7,8 @@ desc="truncate returns EACCES if the named file is not writable by the user"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..8"
 
 n0=`namegen`

--- a/tests/truncate/07.t
+++ b/tests/truncate/07.t
@@ -7,6 +7,8 @@ desc="truncate returns ELOOP if too many symbolic links were encountered in tran
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/truncate/08.t
+++ b/tests/truncate/08.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..22"
-	;;
-FreeBSD:UFS)
-	echo "1..44"
-	;;
-*)
-	quick_exit
-esac
+echo "1..44"
 
 n0=`namegen`
 
@@ -49,8 +40,7 @@ expect 0 truncate ${n0} 123
 expect 123 stat ${n0} size
 expect 0 unlink ${n0}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM truncate ${n0} 123
@@ -59,14 +49,18 @@ FreeBSD:UFS)
 	expect 0 truncate ${n0} 123
 	expect 123 stat ${n0} size
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 truncate ${n0} 123
 	expect 123 stat ${n0} size
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM truncate ${n0} 123
@@ -75,5 +69,4 @@ FreeBSD:UFS)
 	expect 0 truncate ${n0} 123
 	expect 123 stat ${n0} size
 	expect 0 unlink ${n0}
-	;;
-esac
+pop_requirement

--- a/tests/truncate/12.t
+++ b/tests/truncate/12.t
@@ -21,7 +21,7 @@ EFBIG|EINVAL)
 	expect 999999999999999 stat ${n0} size
 	;;
 *)
-	echo "not ok ${ntest}"
+	echo "not ok ${ntest} returned '${r}'"
 	ntest=`expr ${ntest} + 1`
 	;;
 esac

--- a/tests/truncate/12.t
+++ b/tests/truncate/12.t
@@ -12,7 +12,7 @@ echo "1..3"
 n0=`namegen`
 
 expect 0 create ${n0} 0644
-r=`${fstest} truncate ${n0} 999999999999999 2>/dev/null`
+r=`query truncate ${n0} 999999999999999 2>/dev/null`
 case "${r}" in
 EFBIG|EINVAL)
 	expect 0 stat ${n0} size

--- a/tests/unlink/00.t
+++ b/tests/unlink/00.t
@@ -58,6 +58,7 @@ expect ENOENT lstat ${n0} type
 pop_requirement
 
 # successful unlink(2) updates ctime.
+push_requirement link
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}
 ctime1=`query stat ${n0} ctime`
@@ -109,6 +110,7 @@ expect 0 unlink ${n1}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 pop_requirement
 
 # unsuccessful unlink(2) does not update ctime.
@@ -238,6 +240,7 @@ test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 pop_requirement
 
+push_requirement link
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}
 time=`query stat ${n0} ctime`
@@ -246,6 +249,7 @@ expect 0 unlink ${n1}
 ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 unlink ${n0}
+pop_requirement
 
 cd ${cdir}
 expect 0 rmdir ${n2}

--- a/tests/unlink/00.t
+++ b/tests/unlink/00.t
@@ -51,7 +51,7 @@ expect ENOENT lstat ${n0} type
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n1}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -60,7 +60,7 @@ expect 0 unlink ${n0}
 expect 0 mkfifo ${n0} 0644
 expect 0 link ${n0} ${n1}
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n1}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -69,7 +69,7 @@ expect 0 unlink ${n0}
 expect 0 mknod ${n0} b 0644 1 2
 expect 0 link ${n0} ${n1}
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n1}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -78,7 +78,7 @@ expect 0 unlink ${n0}
 expect 0 mknod ${n0} c 0644 1 2
 expect 0 link ${n0} ${n1}
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n1}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -87,7 +87,7 @@ expect 0 unlink ${n0}
 expect 0 bind ${n0}
 expect 0 link ${n0} ${n1}
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n1}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
@@ -96,7 +96,7 @@ expect 0 unlink ${n0}
 # unsuccessful unlink(2) does not update ctime.
 expect 0 create ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EACCES -u 65534 unlink ${n0}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
@@ -104,7 +104,7 @@ expect 0 unlink ${n0}
 
 expect 0 mkfifo ${n0} 0644
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EACCES -u 65534 unlink ${n0}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
@@ -112,7 +112,7 @@ expect 0 unlink ${n0}
 
 expect 0 mknod ${n0} b 0644 1 2
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EACCES -u 65534 unlink ${n0}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
@@ -120,7 +120,7 @@ expect 0 unlink ${n0}
 
 expect 0 mknod ${n0} c 0644 1 2
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EACCES -u 65534 unlink ${n0}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
@@ -128,7 +128,7 @@ expect 0 unlink ${n0}
 
 expect 0 bind ${n0}
 ctime1=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect EACCES -u 65534 unlink ${n0}
 ctime2=`${fstest} stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
@@ -137,7 +137,7 @@ expect 0 unlink ${n0}
 expect 0 mkdir ${n0} 0755
 expect 0 create ${n0}/${n1} 0644
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime
@@ -148,7 +148,7 @@ expect 0 rmdir ${n0}
 expect 0 mkdir ${n0} 0755
 expect 0 mkfifo ${n0}/${n1} 0644
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime
@@ -159,7 +159,7 @@ expect 0 rmdir ${n0}
 expect 0 mkdir ${n0} 0755
 expect 0 mknod ${n0}/${n1} b 0644 1 2
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime
@@ -170,7 +170,7 @@ expect 0 rmdir ${n0}
 expect 0 mkdir ${n0} 0755
 expect 0 mknod ${n0}/${n1} c 0644 1 2
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime
@@ -181,7 +181,7 @@ expect 0 rmdir ${n0}
 expect 0 mkdir ${n0} 0755
 expect 0 bind ${n0}/${n1}
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime
@@ -192,7 +192,7 @@ expect 0 rmdir ${n0}
 expect 0 mkdir ${n0} 0755
 expect 0 symlink test ${n0}/${n1}
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n0}/${n1}
 mtime=`${fstest} stat ${n0} mtime`
 test_check $time -lt $mtime
@@ -203,7 +203,7 @@ expect 0 rmdir ${n0}
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}
 time=`${fstest} stat ${n0} ctime`
-sleep 1
+nap
 expect 0 unlink ${n1}
 ctime=`${fstest} stat ${n0} ctime`
 test_check $time -lt $ctime

--- a/tests/unlink/00.t
+++ b/tests/unlink/00.t
@@ -22,30 +22,40 @@ expect regular lstat ${n0} type
 expect 0 unlink ${n0}
 expect ENOENT lstat ${n0} type
 
+push_requirement ftype_symlink
 expect 0 symlink ${n1} ${n0}
 expect symlink lstat ${n0} type
 expect 0 unlink ${n0}
 expect ENOENT lstat ${n0} type
+pop_requirement
 
+push_requirement ftype_fifo
 expect 0 mkfifo ${n0} 0644
 expect fifo lstat ${n0} type
 expect 0 unlink ${n0}
 expect ENOENT lstat ${n0} type
+pop_requirement
 
+push_requirement ftype_block
 expect 0 mknod ${n0} b 0644 1 2
 expect block lstat ${n0} type
 expect 0 unlink ${n0}
 expect ENOENT lstat ${n0} type
+pop_requirement
 
+push_requirement ftype_char
 expect 0 mknod ${n0} c 0644 1 2
 expect char lstat ${n0} type
 expect 0 unlink ${n0}
 expect ENOENT lstat ${n0} type
+pop_requirement
 
+push_requirement ftype_socket
 expect 0 bind ${n0}
 expect socket lstat ${n0} type
 expect 0 unlink ${n0}
 expect ENOENT lstat ${n0} type
+pop_requirement
 
 # successful unlink(2) updates ctime.
 expect 0 create ${n0} 0644
@@ -57,6 +67,7 @@ ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
+push_requirement ftype_fifo
 expect 0 mkfifo ${n0} 0644
 expect 0 link ${n0} ${n1}
 ctime1=`query stat ${n0} ctime`
@@ -65,7 +76,9 @@ expect 0 unlink ${n1}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_block
 expect 0 mknod ${n0} b 0644 1 2
 expect 0 link ${n0} ${n1}
 ctime1=`query stat ${n0} ctime`
@@ -74,7 +87,9 @@ expect 0 unlink ${n1}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_char
 expect 0 mknod ${n0} c 0644 1 2
 expect 0 link ${n0} ${n1}
 ctime1=`query stat ${n0} ctime`
@@ -83,7 +98,9 @@ expect 0 unlink ${n1}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_socket
 expect 0 bind ${n0}
 expect 0 link ${n0} ${n1}
 ctime1=`query stat ${n0} ctime`
@@ -92,8 +109,10 @@ expect 0 unlink ${n1}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
 # unsuccessful unlink(2) does not update ctime.
+push_requirement root
 expect 0 create ${n0} 0644
 ctime1=`query stat ${n0} ctime`
 nap
@@ -102,6 +121,7 @@ ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
+push_requirement ftype_fifo
 expect 0 mkfifo ${n0} 0644
 ctime1=`query stat ${n0} ctime`
 nap
@@ -109,7 +129,9 @@ expect EACCES -u 65534 unlink ${n0}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_block
 expect 0 mknod ${n0} b 0644 1 2
 ctime1=`query stat ${n0} ctime`
 nap
@@ -117,7 +139,9 @@ expect EACCES -u 65534 unlink ${n0}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_char
 expect 0 mknod ${n0} c 0644 1 2
 ctime1=`query stat ${n0} ctime`
 nap
@@ -125,7 +149,9 @@ expect EACCES -u 65534 unlink ${n0}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement ftype_socket
 expect 0 bind ${n0}
 ctime1=`query stat ${n0} ctime`
 nap
@@ -133,6 +159,8 @@ expect EACCES -u 65534 unlink ${n0}
 ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
+pop_requirement
+pop_requirement
 
 expect 0 mkdir ${n0} 0755
 expect 0 create ${n0}/${n1} 0644
@@ -145,6 +173,7 @@ ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
+push_requirement ftype_fifo
 expect 0 mkdir ${n0} 0755
 expect 0 mkfifo ${n0}/${n1} 0644
 time=`query stat ${n0} ctime`
@@ -155,7 +184,9 @@ test_check $time -lt $mtime
 ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
+pop_requirement
 
+push_requirement ftype_block
 expect 0 mkdir ${n0} 0755
 expect 0 mknod ${n0}/${n1} b 0644 1 2
 time=`query stat ${n0} ctime`
@@ -166,7 +197,9 @@ test_check $time -lt $mtime
 ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
+pop_requirement
 
+push_requirement ftype_char
 expect 0 mkdir ${n0} 0755
 expect 0 mknod ${n0}/${n1} c 0644 1 2
 time=`query stat ${n0} ctime`
@@ -177,7 +210,9 @@ test_check $time -lt $mtime
 ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
+pop_requirement
 
+push_requirement ftype_socket
 expect 0 mkdir ${n0} 0755
 expect 0 bind ${n0}/${n1}
 time=`query stat ${n0} ctime`
@@ -188,7 +223,9 @@ test_check $time -lt $mtime
 ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
+pop_requirement
 
+push_requirement ftype_symlink
 expect 0 mkdir ${n0} 0755
 expect 0 symlink test ${n0}/${n1}
 time=`query stat ${n0} ctime`
@@ -199,6 +236,7 @@ test_check $time -lt $mtime
 ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
+pop_requirement
 
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}

--- a/tests/unlink/00.t
+++ b/tests/unlink/00.t
@@ -50,162 +50,162 @@ expect ENOENT lstat ${n0} type
 # successful unlink(2) updates ctime.
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n1}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mkfifo ${n0} 0644
 expect 0 link ${n0} ${n1}
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n1}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mknod ${n0} b 0644 1 2
 expect 0 link ${n0} ${n1}
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n1}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mknod ${n0} c 0644 1 2
 expect 0 link ${n0} ${n1}
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n1}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 expect 0 bind ${n0}
 expect 0 link ${n0} ${n1}
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n1}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -lt $ctime2
 expect 0 unlink ${n0}
 
 # unsuccessful unlink(2) does not update ctime.
 expect 0 create ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EACCES -u 65534 unlink ${n0}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mkfifo ${n0} 0644
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EACCES -u 65534 unlink ${n0}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mknod ${n0} b 0644 1 2
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EACCES -u 65534 unlink ${n0}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mknod ${n0} c 0644 1 2
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EACCES -u 65534 unlink ${n0}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
 expect 0 bind ${n0}
-ctime1=`${fstest} stat ${n0} ctime`
+ctime1=`query stat ${n0} ctime`
 nap
 expect EACCES -u 65534 unlink ${n0}
-ctime2=`${fstest} stat ${n0} ctime`
+ctime2=`query stat ${n0} ctime`
 test_check $ctime1 -eq $ctime2
 expect 0 unlink ${n0}
 
 expect 0 mkdir ${n0} 0755
 expect 0 create ${n0}/${n1} 0644
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
 expect 0 mkdir ${n0} 0755
 expect 0 mkfifo ${n0}/${n1} 0644
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
 expect 0 mkdir ${n0} 0755
 expect 0 mknod ${n0}/${n1} b 0644 1 2
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
 expect 0 mkdir ${n0} 0755
 expect 0 mknod ${n0}/${n1} c 0644 1 2
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
 expect 0 mkdir ${n0} 0755
 expect 0 bind ${n0}/${n1}
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
 expect 0 mkdir ${n0} 0755
 expect 0 symlink test ${n0}/${n1}
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n0}/${n1}
-mtime=`${fstest} stat ${n0} mtime`
+mtime=`query stat ${n0} mtime`
 test_check $time -lt $mtime
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 rmdir ${n0}
 
 expect 0 create ${n0} 0644
 expect 0 link ${n0} ${n1}
-time=`${fstest} stat ${n0} ctime`
+time=`query stat ${n0} ctime`
 nap
 expect 0 unlink ${n1}
-ctime=`${fstest} stat ${n0} ctime`
+ctime=`query stat ${n0} ctime`
 test_check $time -lt $ctime
 expect 0 unlink ${n0}
 

--- a/tests/unlink/05.t
+++ b/tests/unlink/05.t
@@ -7,6 +7,8 @@ desc="unlink returns EACCES when search permission is denied for a component of 
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/unlink/06.t
+++ b/tests/unlink/06.t
@@ -7,6 +7,8 @@ desc="unlink returns EACCES when write permission is denied on the directory con
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..10"
 
 n0=`namegen`

--- a/tests/unlink/07.t
+++ b/tests/unlink/07.t
@@ -7,6 +7,8 @@ desc="unlink returns ELOOP if too many symbolic links were encountered in transl
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
+
 echo "1..6"
 
 n0=`namegen`

--- a/tests/unlink/09.t
+++ b/tests/unlink/09.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..15"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 
@@ -43,24 +34,26 @@ expect 0 chflags ${n0} none
 todo FreeBSD:ZFS "Removing a file protected by SF_APPEND should return EPERM."
 expect 0 unlink ${n0}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM unlink ${n0}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect EPERM unlink ${n0}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 create ${n0} 0644
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM unlink ${n0}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}
-	;;
-esac
+pop_requirement

--- a/tests/unlink/10.t
+++ b/tests/unlink/10.t
@@ -9,16 +9,7 @@ dir=`dirname $0`
 
 require chflags
 
-case "${os}:${fs}" in
-FreeBSD:ZFS)
-	echo "1..16"
-	;;
-FreeBSD:UFS)
-	echo "1..30"
-	;;
-*)
-	quick_exit
-esac
+echo "1..30"
 
 n0=`namegen`
 n1=`namegen`
@@ -44,25 +35,27 @@ expect 0 chflags ${n0} none
 todo FreeBSD:ZFS "Removing a file from a directory protected by SF_APPEND should return EPERM."
 expect 0 unlink ${n0}/${n1}
 
-case "${os}:${fs}" in
-FreeBSD:UFS)
+push_requirement chflags_UF_IMMUTABLE
 	expect 0 create ${n0}/${n1} 0644
 	expect 0 chflags ${n0} UF_IMMUTABLE
 	expect EPERM unlink ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
+pop_requirement
 
+push_requirement chflags_UF_NOUNLINK
 	expect 0 create ${n0}/${n1} 0644
 	expect 0 chflags ${n0} UF_NOUNLINK
 	expect 0 unlink ${n0}/${n1}
 	expect 0 chflags ${n0} none
+pop_requirement
 
+push_requirement chflags_UF_APPEND
 	expect 0 create ${n0}/${n1} 0644
 	expect 0 chflags ${n0} UF_APPEND
 	expect EPERM unlink ${n0}/${n1}
 	expect 0 chflags ${n0} none
 	expect 0 unlink ${n0}/${n1}
-	;;
-esac
+pop_requirement
 
 expect 0 rmdir ${n0}

--- a/tests/unlink/11.t
+++ b/tests/unlink/11.t
@@ -22,6 +22,8 @@ expect 0 chmod ${n0} 01777
 expect 0 chown ${n0} 65534 65534
 
 for type in regular fifo block char socket symlink; do
+	push_requirement ftype_${type}
+
 	# User owns both: the sticky directory and the file.
 	expect 0 chown ${n0} 65534 65534
 	create_file ${type} ${n0}/${n1} 65534 65534
@@ -56,6 +58,8 @@ for type in regular fifo block char socket symlink; do
 		expect ${type},${id},${id} lstat ${n0}/${n1} type,uid,gid
 		expect 0 unlink ${n0}/${n1}
 	done
+
+	pop_requirement
 done
 
 expect 0 rmdir ${n0}

--- a/tests/unlink/11.t
+++ b/tests/unlink/11.t
@@ -7,6 +7,8 @@ desc="unlink returns EACCES or EPERM if the directory containing the file is mar
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
+
 echo "1..270"
 
 n0=`namegen`

--- a/tests/utimensat/00.t
+++ b/tests/utimensat/00.t
@@ -7,7 +7,7 @@ desc="utimensat changes timestamps on any type of file"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..32"
 

--- a/tests/utimensat/00.t
+++ b/tests/utimensat/00.t
@@ -21,6 +21,8 @@ cd ${n1}
 DATE1=1900000000 #Sun Mar 17 11:46:40 MDT 2030
 DATE2=1950000000 #Fri Oct 17 04:40:00 MDT 2031
 for type in regular dir fifo block char socket; do
+	push_requirement ftype_${type}
+
 	create_file ${type} ${n0}
 	expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 $DATE2 0 0
 	expect $DATE1 lstat ${n0} atime
@@ -30,6 +32,8 @@ for type in regular dir fifo block char socket; do
 	else
 		expect 0 unlink ${n0}
 	fi
+
+	pop_requirement
 done
 
 cd ${cdir}

--- a/tests/utimensat/01.t
+++ b/tests/utimensat/01.t
@@ -21,13 +21,13 @@ cd ${n1}
 
 
 create_file regular ${n0}
-old_mtime=`$fstest lstat ${n0} mtime`
-old_atime=`$fstest lstat ${n0} atime`
+old_mtime=`query lstat ${n0} mtime`
+old_atime=`query lstat ${n0} atime`
 nap
 
 expect 0 open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_NOW 0 UTIME_NOW 0
-new_mtime=`$fstest lstat ${n0} mtime`
-new_atime=`$fstest lstat ${n0} atime`
+new_mtime=`query lstat ${n0} mtime`
+new_atime=`query lstat ${n0} atime`
 delta_mtime=$(( $new_mtime - $old_mtime ))
 delta_atime=$(( $new_atime - $old_atime ))
 

--- a/tests/utimensat/01.t
+++ b/tests/utimensat/01.t
@@ -7,7 +7,7 @@ desc="utimensat with UTIME_NOW will set the will set typestamps to now"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..7"
 

--- a/tests/utimensat/01.t
+++ b/tests/utimensat/01.t
@@ -23,7 +23,7 @@ cd ${n1}
 create_file regular ${n0}
 old_mtime=`$fstest lstat ${n0} mtime`
 old_atime=`$fstest lstat ${n0} atime`
-sleep 1	# Ensure that future timestamps will be different than this one
+nap
 
 expect 0 open . O_RDONLY : utimensat 0 ${n0} 0 UTIME_NOW 0 UTIME_NOW 0
 new_mtime=`$fstest lstat ${n0} mtime`

--- a/tests/utimensat/02.t
+++ b/tests/utimensat/02.t
@@ -21,7 +21,7 @@ cdir=`pwd`
 cd ${n1}
 
 create_file regular ${n0}
-orig_mtime=`$fstest lstat ${n0} mtime`
+orig_mtime=`query lstat ${n0} mtime`
 expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 0 0 UTIME_OMIT 0
 expect $DATE1 lstat ${n0} atime
 expect $orig_mtime lstat ${n0} mtime

--- a/tests/utimensat/02.t
+++ b/tests/utimensat/02.t
@@ -7,7 +7,7 @@ desc="utimensat with UTIME_OMIT will leave the time unchanged"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..10"
 

--- a/tests/utimensat/03.t
+++ b/tests/utimensat/03.t
@@ -7,9 +7,8 @@ desc="utimensat can update birthtimes"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
-
 require stat_st_birthtime
+require utimensat
 
 echo "1..12"
 

--- a/tests/utimensat/04.t
+++ b/tests/utimensat/04.t
@@ -7,7 +7,7 @@ desc="utimensat can set mtime < atime or vice versa"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..10"
 

--- a/tests/utimensat/05.t
+++ b/tests/utimensat/05.t
@@ -43,7 +43,7 @@ expect $DATE6 lstat ${n0} mtime
 # $DATE3.  However, if atime is enabled, then ${n2}'s atime will be the current
 # system time.  For this test, it's sufficient to simply check that it didn't
 # get set to DATE5
-test_check "$DATE5" -ne `"$fstest" lstat ${n2} atime`
+test_check "$DATE5" -ne `query lstat ${n2} atime`
 expect $DATE4 lstat ${n2} mtime
 
 expect 0 unlink ${n0}

--- a/tests/utimensat/05.t
+++ b/tests/utimensat/05.t
@@ -7,6 +7,7 @@ desc="utimensat can follow symlinks"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require ftype_symlink
 require utimensat
 
 echo "1..16"

--- a/tests/utimensat/05.t
+++ b/tests/utimensat/05.t
@@ -7,7 +7,7 @@ desc="utimensat can follow symlinks"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..16"
 

--- a/tests/utimensat/06.t
+++ b/tests/utimensat/06.t
@@ -7,8 +7,8 @@ desc="utimensat with UTIME_NOW will work if the caller has write permission"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
-require "UTIME_NOW"
+require utimensat
+require UTIME_NOW
 
 echo "1..13"
 

--- a/tests/utimensat/06.t
+++ b/tests/utimensat/06.t
@@ -7,6 +7,7 @@ desc="utimensat with UTIME_NOW will work if the caller has write permission"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
 require utimensat
 require UTIME_NOW
 

--- a/tests/utimensat/07.t
+++ b/tests/utimensat/07.t
@@ -7,7 +7,7 @@ desc="utimensat will work if the caller is the owner or root"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..17"
 

--- a/tests/utimensat/07.t
+++ b/tests/utimensat/07.t
@@ -7,6 +7,7 @@ desc="utimensat will work if the caller is the owner or root"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
+require root
 require utimensat
 
 echo "1..17"

--- a/tests/utimensat/08.t
+++ b/tests/utimensat/08.t
@@ -28,12 +28,9 @@ create_file regular ${n0} 0644
 expect 0 open . O_RDONLY : utimensat 0 ${n0} $DATE1 $DATE1_NS $DATE2 $DATE2_NS 0
 expect $DATE1_NS lstat ${n0} atime_ns
 expect $DATE2_NS lstat ${n0} mtime_ns
-if supported "stat_st_birthtime"; then
+push_requirement stat_st_birthtime
 	expect $DATE2_NS lstat ${n0} birthtime_ns
-else
-	test_check true
-fi
-
+pop_requirement
 expect 0 unlink ${n0}
 
 cd ${cdir}

--- a/tests/utimensat/08.t
+++ b/tests/utimensat/08.t
@@ -7,7 +7,7 @@ desc="utimensat can set timestamps with subsecond precision"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..9"
 

--- a/tests/utimensat/09.t
+++ b/tests/utimensat/09.t
@@ -7,11 +7,9 @@ desc="utimensat is y2038 compliant"
 dir=`dirname $0`
 . ${dir}/../misc.sh
 
-require "utimensat"
+require utimensat
 
 echo "1..7"
-
-require utimensat
 
 n0=`namegen`
 n1=`namegen`


### PR DESCRIPTION
Introduces two new functions, "push_requirement" and "pop_requirement", that govern a stack of current requirements. If the requirements are unmet, tests are skipped. This has several positive effects:

* Allows to run as non-root the subset of pjdfstests that work as non-root
* Allows to selectively disable tests for certain file types (closes #45)
* Simplifies test plan calculation ("`1..n`" lines)

While at it, this series also fixes a bug in `rename/09.t` and `rename/10.t` and provides more information in the output (not quite fixing #27, but certainly helping).