### PR TITLE
Fix variable name collision in the rename tests

### DIFF
--- a/tests/rename/09.t
+++ b/tests/rename/09.t
@@ -26,14 +26,14 @@ expect 0 chown ${n0} 65534 65534
 expect 0 mkdir ${n1} 0755
 expect 0 chown ${n1} 65534 65534
 
-for type in regular fifo block char socket symlink; do
+for type2 in regular fifo block char socket symlink; do
 	# User owns both: the source sticky directory and the source file.
 	expect 0 chown ${n0} 65534 65534
-	create_file ${type} ${n0}/${n2} 65534 65534
+	create_file ${type2} ${n0}/${n2} 65534 65534
 	inode=`${fstest} lstat ${n0}/${n2} inode`
 
-	for type in none regular fifo block char socket symlink; do
-		create_file ${type} ${n1}/${n3} 65534 65534
+	for type3 in none regular fifo block char socket symlink; do
+		create_file ${type3} ${n1}/${n3} 65534 65534
 		expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 		expect ENOENT lstat ${n0}/${n2} inode
 		expect ${inode},65534,65534 lstat ${n1}/${n3} inode,uid,gid
@@ -47,11 +47,11 @@ for type in regular fifo block char socket symlink; do
 	# User owns the source sticky directory, but doesn't own the source file.
 	for id in 0 65533; do
 		expect 0 chown ${n0} 65534 65534
-		create_file ${type} ${n0}/${n2} ${id} ${id}
+		create_file ${type2} ${n0}/${n2} ${id} ${id}
 		inode=`${fstest} lstat ${n0}/${n2} inode`
 
-		for type in none regular fifo block char socket symlink; do
-			create_file ${type} ${n1}/${n3} 65534 65534
+		for type3 in none regular fifo block char socket symlink; do
+			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
 			expect ${inode},${id},${id} lstat ${n1}/${n3} inode,uid,gid
@@ -66,11 +66,11 @@ for type in regular fifo block char socket symlink; do
 	# User owns the source file, but doesn't own the source sticky directory.
 	for id in 0 65533; do
 		expect 0 chown ${n0} ${id} ${id}
-		create_file ${type} ${n0}/${n2} 65534 65534
+		create_file ${type2} ${n0}/${n2} 65534 65534
 		inode=`${fstest} lstat ${n0}/${n2} inode`
 
-		for type in none regular fifo block char socket symlink; do
-			create_file ${type} ${n1}/${n3} 65534 65534
+		for type3 in none regular fifo block char socket symlink; do
+			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
 			expect ${inode},65534,65534 lstat ${n1}/${n3} inode,uid,gid
@@ -85,14 +85,14 @@ for type in regular fifo block char socket symlink; do
 	# User doesn't own the source sticky directory nor the source file.
 	for id in 0 65533; do
 		expect 0 chown ${n0} ${id} ${id}
-		create_file ${type} ${n0}/${n2} ${id} ${id}
+		create_file ${type2} ${n0}/${n2} ${id} ${id}
 		inode=`${fstest} lstat ${n0}/${n2} inode`
 
-		for type in none regular fifo block char socket symlink; do
-			create_file ${type} ${n1}/${n3} 65534 65534
+		for type3 in none regular fifo block char socket symlink; do
+			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ${inode},${id},${id} lstat ${n0}/${n2} inode,uid,gid
-			if [ "${type}" != "none" ]; then
+			if [ "${type3}" != "none" ]; then
 				expect 65534,65534 lstat ${n1}/${n3} uid,gid
 				expect 0 unlink ${n1}/${n3}
 			fi

--- a/tests/rename/10.t
+++ b/tests/rename/10.t
@@ -25,14 +25,14 @@ expect 0 chown ${n0} 65534 65534
 expect 0 mkdir ${n1} 0755
 expect 0 chmod ${n1} 01777
 
-for type in regular fifo block char socket symlink; do
+for type2 in regular fifo block char socket symlink; do
 	# User owns both: the sticky directory and the destination file.
 	expect 0 chown ${n1} 65534 65534
-	create_file ${type} ${n0}/${n2} 65534 65534
+	create_file ${type2} ${n0}/${n2} 65534 65534
 	inode=`${fstest} lstat ${n0}/${n2} inode`
 
-	for type in regular fifo block char socket symlink; do
-		create_file ${type} ${n1}/${n3} 65534 65534
+	for type3 in regular fifo block char socket symlink; do
+		create_file ${type3} ${n1}/${n3} 65534 65534
 		expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 		expect ENOENT lstat ${n0}/${n2} inode
 		expect ${inode} lstat ${n1}/${n3} inode
@@ -46,11 +46,11 @@ for type in regular fifo block char socket symlink; do
 	# User owns the sticky directory, but doesn't own the destination file.
 	for id in 0 65533; do
 		expect 0 chown ${n1} 65534 65534
-		create_file ${type} ${n0}/${n2} 65534 65534
+		create_file ${type2} ${n0}/${n2} 65534 65534
 		inode=`${fstest} lstat ${n0}/${n2} inode`
 
-		for type in regular fifo block char socket symlink; do
-			create_file ${type} ${n1}/${n3} ${id} ${id}
+		for type3 in regular fifo block char socket symlink; do
+			create_file ${type3} ${n1}/${n3} ${id} ${id}
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
 			expect ${inode} lstat ${n1}/${n3} inode
@@ -65,11 +65,11 @@ for type in regular fifo block char socket symlink; do
 	# User owns the destination file, but doesn't own the sticky directory.
 	for id in 0 65533; do
 		expect 0 chown ${n1} ${id} ${id}
-		create_file ${type} ${n0}/${n2} 65534 65534
+		create_file ${type2} ${n0}/${n2} 65534 65534
 		inode=`${fstest} lstat ${n0}/${n2} inode`
 
-		for type in regular fifo block char socket symlink; do
-			create_file ${type} ${n1}/${n3} 65534 65534
+		for type3 in regular fifo block char socket symlink; do
+			create_file ${type3} ${n1}/${n3} 65534 65534
 			expect 0 -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ENOENT lstat ${n0}/${n2} inode
 			expect ${inode} lstat ${n1}/${n3} inode
@@ -84,11 +84,11 @@ for type in regular fifo block char socket symlink; do
 	# User doesn't own the sticky directory nor the destination file.
 	for id in 0 65533; do
 		expect 0 chown ${n1} ${id} ${id}
-		create_file ${type} ${n0}/${n2} 65534 65534
+		create_file ${type2} ${n0}/${n2} 65534 65534
 		inode=`${fstest} lstat ${n0}/${n2} inode`
 
-		for type in regular fifo block char socket symlink; do
-			create_file ${type} ${n1}/${n3} ${id} ${id}
+		for type3 in regular fifo block char socket symlink; do
+			create_file ${type3} ${n1}/${n3} ${id} ${id}
 			expect "EACCES|EPERM" -u 65534 -g 65534 rename ${n0}/${n2} ${n1}/${n3}
 			expect ${inode} lstat ${n0}/${n2} inode
 			expect ${id},${id} lstat ${n1}/${n3} uid,gid


### PR DESCRIPTION
Two rename tests contained nested loops that used the same loop variable
in each.  The inner loops overwrote the loop variable from the outer
loop.  This being sh, they didn't simply shadow the outer variable.

Fixes #61