### PR TITLE
Reset ACLs between each subtest in granular/05.t

### DIFF
--- a/tests/granular/05.t
+++ b/tests/granular/05.t
@@ -9,7 +9,7 @@ dir=`dirname $0`
 
 [ "${os}:${fs}" = "FreeBSD:ZFS" ] || quick_exit
 
-echo "1..68"
+echo "1..89"
 
 n0=`namegen`
 n1=`namegen`
@@ -28,6 +28,7 @@ expect 0 prependacl . user:65534:write_data::allow
 expect 0 -u 65534 -g 65534 rmdir ${n0}
 
 # Moving directory elsewhere allowed on writable directory.
+/bin/setfacl -b .
 expect 0 mkdir ${n0} 0777
 expect 0 prependacl . user:65534:write_data::deny
 expect EACCES -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
@@ -36,13 +37,16 @@ expect 0 -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
 
 # 12
 # Moving directory from elsewhere allowed on writable directory.
+/bin/setfacl -b .
 expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 expect 0 prependacl . user:65534:append_data::allow
 expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 -u 65534 -g 65534 rmdir ${n0}
+expect 0 rmdir ${n0}
 
 # Moving directory from elsewhere overwriting local directory allowed
 # on writable directory.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:append_data::allow
 expect 0 mkdir ${n0} 0755
 expect 0 mkdir ../${n3}/${n0} 0777
 expect 0 prependacl . user:65534:write_data::deny
@@ -53,17 +57,28 @@ expect 0 -u 65534 -g 65534 rmdir ${n0}
 
 # 23
 # Denied DELETE changes nothing wrt removing.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:write_data::allow
+expect 0 prependacl . user:65534:append_data::allow
 expect 0 mkdir ${n0} 0755
 expect 0 prependacl ${n0} user:65534:delete::deny
 expect 0 -u 65534 -g 65534 rmdir ${n0}
 
 # Denied DELETE changes nothing wrt moving elsewhere or from elsewhere.
+/bin/setfacl -b .
+# XXX ACL_WRITE_DATA is required to delete directories, but ACL_APPEND_DATA is
+# required to create them?
+expect 0 prependacl . user:65534:write_data::allow
 expect 0 mkdir ${n0} 0777
+expect 0 prependacl ${n0} user:65534:delete::deny
 expect 0 -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:append_data::allow
 expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 -u 65534 -g 65534 rmdir ${n0}
+expect 0 rmdir ${n0}
 
 # DELETE_CHILD denies unlink on writable directory.
+/bin/setfacl -b .
 expect 0 mkdir ${n0} 0755
 expect 0 prependacl . user:65534:delete_child::deny
 expect EPERM -u 65534 -g 65534 rmdir ${n0}
@@ -71,25 +86,37 @@ expect 0 rmdir ${n0}
 
 # 35
 # DELETE_CHILD denies moving directory elsewhere.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:write_data::allow
+expect 0 prependacl . user:65534:delete_child::deny
 expect 0 mkdir ${n0} 0777
 expect EPERM -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
 expect 0 rename ${n0} ../${n3}/${n0}
 
 # DELETE_CHILD does not deny moving directory from elsewhere
 # to a writable directory.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:append_data::allow
+expect 0 prependacl . user:65534:delete_child::deny
 expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 
 # DELETE_CHILD denies moving directory from elsewhere
 # to a writable directory overwriting local directory.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:append_data::allow
+expect 0 prependacl . user:65534:delete_child::deny
 expect 0 mkdir ../${n3}/${n0} 0755
 expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 
 # DELETE allowed on directory allows for unlinking, no matter
 # what permissions on containing directory are.
+/bin/setfacl -b .
 expect 0 prependacl ${n0} user:65534:delete::allow
 expect 0 -u 65534 -g 65534 rmdir ${n0}
 
 # Same for moving the directory elsewhere.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:append_data::allow
 expect 0 mkdir ${n0} 0777
 expect 0 prependacl ${n0} user:65534:delete::allow
 expect 0 -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
@@ -97,52 +124,63 @@ expect 0 -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
 # 46
 # Same for moving the directory from elsewhere into a writable
 # directory with DELETE_CHILD denied.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:append_data::allow
+expect 0 prependacl . user:65534:delete_child::deny
 expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 expect 0 rmdir ${n0}
 
 # DELETE does not allow for overwriting a directory in a unwritable
 # directory with DELETE_CHILD denied.
+/bin/setfacl -b .
 expect 0 mkdir ${n0} 0755
 expect 0 mkdir ../${n3}/${n0} 0777
-expect 0 prependacl . user:65534:write_data::deny
 expect 0 prependacl . user:65534:delete_child::deny
 expect EPERM -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 expect 0 prependacl ${n0} user:65534:delete::allow
-# XXX: expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
+expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
+expect 0 rmdir ${n0}
 
 # 54
 # But it allows for plain deletion.
-# XXX: expect 0 -u 65534 -g 65534 rmdir ${n0}
-expect 0 rmdir ${n0}
+/bin/setfacl -b .
+expect 0 mkdir ${n0} 0755
+expect 0 prependacl ${n0} user:65534:delete::allow
+expect 0 -u 65534 -g 65534 rmdir ${n0}
 
 # DELETE_CHILD allowed on unwritable directory.
+/bin/setfacl -b .
 expect 0 mkdir ${n0} 0755
 expect 0 prependacl . user:65534:delete_child::allow
 expect 0 -u 65534 -g 65534 rmdir ${n0}
 
 # Moving things elsewhere is allowed.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:delete_child::allow
 expect 0 mkdir ${n0} 0777
 expect 0 -u 65534 -g 65534 rename ${n0} ../${n3}/${n0}
 
 # 60
 # Moving things back is not.
-# XXX: expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:delete_child::allow
+expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 
 # Even if we're overwriting.
-# XXX: expect 0 mkdir ${n0} 0755
-expect 0 mkdir ../${n3}/${n0} 0777
-# XXX: expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 mkdir ../${n3}/${n0} 0777
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:delete_child::allow
+expect 0 mkdir ${n0} 0755
+expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 
 # Even if we have DELETE on the existing directory.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:delete_child::allow
 expect 0 prependacl ${n0} user:65534:delete::allow
-# XXX: expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
-expect 0 -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
+expect EACCES -u 65534 -g 65534 rename ../${n3}/${n0} ${n0}
 
 # Denied DELETE changes nothing wrt removing.
+/bin/setfacl -b .
+expect 0 prependacl . user:65534:delete_child::allow
 expect 0 prependacl ${n0} user:65534:delete::deny
 expect 0 -u 65534 -g 65534 rmdir ${n0}
 


### PR DESCRIPTION
This way subtests can stand alone rather than depending on each other.

Also, fix several expectations.  Comments indicate that the correct
behavior was not observed, but rather than annotate it with a "todo"
statement the assertions were altered to expect incorrect behavior
instead.  But in fact the correct behavior is observed when starting
with a fresh ACL for each subtest.