### PR TITLE
rename/24.t: mark Btrfs link-count differences as TODO

### DIFF
--- a/tests/rename/24.t
+++ b/tests/rename/24.t
@@ -19,16 +19,40 @@ expect 0 mkdir ${src_parent}/${src} 0755
 cdir=`pwd`
 
 # Initial conditions
-expect 3 lstat ${src_parent} nlink
-expect 2 lstat ${dst_parent} nlink
+case  "$fs" in
+    btrfs|BTRFS)
+	todo Linux "Btrfs uses CoW; link count semantics differ from POSIX."
+	expect 3 lstat ${src_parent} nlink
+
+	todo Linux "Btrfs uses CoW; link count semantics differ from POSIX."
+	expect 2 lstat ${dst_parent} nlink
+	;;
+*)
+	expect 3 lstat ${src_parent} nlink
+	expect 2 lstat ${dst_parent} nlink
+	;;
+esac
+
 dotdot_inode=`${fstest} lstat ${src_parent} inode`
 expect ${dotdot_inode} lstat ${src_parent}/${src}/.. inode
 
 expect 0 rename ${src_parent}/${src} ${dst_parent}/${dst}
 
 # The .. link and parents' nlinks values should be updated
-expect 2 lstat ${src_parent} nlink
-expect 3 lstat ${dst_parent} nlink
+case "$fs" in
+    btrfs|BTRFS)
+	todo Linux "Btrfs uses CoW; link count semantics differ from POSIX."
+	expect 2 lstat ${src_parent} nlink
+
+	todo Linux "Btrfs uses CoW; link count semantics differ from POSIX."
+	expect 3 lstat ${dst_parent} nlink
+	;;
+*)
+	expect 2 lstat ${src_parent} nlink
+	expect 3 lstat ${dst_parent} nlink
+	;;
+esac
+
 dotdot_inode=`${fstest} lstat ${dst_parent} inode`
 expect ${dotdot_inode} lstat ${dst_parent}/${dst}/.. inode
 


### PR DESCRIPTION
### Problem
rename/24.t test fails on Btrfs due to copy-on-write semantics. 
The test expects hard-coded link counts (nlink) that do not match Btrfs behavior.

Subtests 4,5,8,9 fail:
- Expected 3, got 1
- Expected 2, got 1
- Expected 2, got 1
- Expected 3, got 1

### Fix
- Detect filesystem type in the test
- Apply TODO annotations for affected subtests on Btrfs
- TAP plan remains valid (1..13)
- ext4, xfs, and other POSIX-compliant filesystems are unaffected

### Result
- Btrfs runs report `not ok … # TODO` for known deviations
```
# prove -rv -f /mnt/pjdfstest/ tests/rename/24.t
tests/rename/24.t ..
1..13
ok 1
ok 2
ok 3
not ok 4 # TODO Btrfs uses CoW; link count semantics differ from POSIX.
not ok 5 # TODO Btrfs uses CoW; link count semantics differ from POSIX.
ok 6
ok 7
not ok 8 # TODO Btrfs uses CoW; link count semantics differ from POSIX.
not ok 9 # TODO Btrfs uses CoW; link count semantics differ from POSIX.
ok 10
ok 11
ok 12
ok 13
ok
All tests successful.
Files=1, Tests=13,  0 wallclock secs ( 0.05 usr  0.00 sys +  0.10 cusr  0.04 csys =  0.19 CPU)
Result: PASS
```

- All tests pass on ext4/xfs
```
# prove -rv tests/rename/24.t
tests/rename/24.t ..
1..13
ok 1
ok 2
ok 3
ok 4
ok 5
ok 6
ok 7
ok 8
ok 9
ok 10
ok 11
ok 12
ok 13
ok
All tests successful.
Files=1, Tests=13,  0 wallclock secs ( 0.04 usr  0.00 sys +  0.07 cusr  0.04 csys =  0.15 CPU)
Result: PASS
```