### PR TITLE
Fix link count test

### DIFF
--- a/tests/ftruncate/12.t
+++ b/tests/ftruncate/12.t
@@ -22,7 +22,7 @@ EFBIG|EINVAL)
 	;;
 *)
 	echo "not ok ${ntest}"
-	ntest=`expr ${ntest} + 1`
+	ntest=$((ntest + 1))
 	;;
 esac
 expect 0 unlink ${n0}

--- a/tests/link/05.t
+++ b/tests/link/05.t
@@ -2,7 +2,7 @@
 # vim: filetype=sh noexpandtab ts=8 sw=8
 # $FreeBSD: head/tools/regression/pjdfstest/tests/link/05.t 211352 2010-08-15 21:24:17Z pjd $
 
-desc="link returns EMLINK if the link count of the file named by name1 would exceed 32767"
+desc="link returns EMLINK if the link count of the file named by name1 would exceed {PC_LINK_MAX}"
 
 dir=`dirname $0`
 . ${dir}/../misc.sh
@@ -18,19 +18,20 @@ n1=`namegen`
 n2=`namegen`
 
 expect 0 mkdir ${n0} 0755
-n=`mdconfig -a -n -t malloc -s 1m` || exit
+n=`mdconfig -a -n -t malloc -s 2m` || exit
 newfs -i 1 /dev/md${n} >/dev/null || exit
 mount /dev/md${n} ${n0} || exit
+link_max=`${fstest} pathconf ${n0} _PC_LINK_MAX`
 expect 0 create ${n0}/${n1} 0644
 i=1
-while :; do
+while [ ${i} -le ${link_max} ]; do
 	link ${n0}/${n1} ${n0}/${i} >/dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		break
 	fi
 	i=`expr $i + 1`
 done
-test_check $i -eq 32767
+test_check $i -eq ${link_max}
 
 expect EMLINK link ${n0}/${n1} ${n0}/${n2}
 

--- a/tests/link/05.t
+++ b/tests/link/05.t
@@ -29,7 +29,7 @@ while [ ${i} -le ${link_max} ]; do
 	if [ $? -ne 0 ]; then
 		break
 	fi
-	i=`expr $i + 1`
+	i=$((i + 1))
 done
 test_check $i -eq ${link_max}
 

--- a/tests/link/15.t
+++ b/tests/link/15.t
@@ -28,7 +28,7 @@ while :; do
 	if [ $? -ne 0 ]; then
 		break
 	fi
-	i=`expr $i + 1`
+	i=$((i + 1))
 done
 expect ENOSPC link ${n0}/${n1} ${n0}/${n2}
 umount /dev/md${n}

--- a/tests/mkdir/11.t
+++ b/tests/mkdir/11.t
@@ -24,7 +24,7 @@ while :; do
 	if [ $? -ne 0 ]; then
 		break
 	fi
-	i=`expr $i + 1`
+	i=$((i + 1))
 done
 expect ENOSPC mkdir ${n0}/${n1} 0755
 umount /dev/md${n}

--- a/tests/mkfifo/11.t
+++ b/tests/mkfifo/11.t
@@ -24,7 +24,7 @@ while :; do
 	if [ $? -ne 0 ]; then
 		break
 	fi
-	i=`expr $i + 1`
+	i=$((i + 1))
 done
 expect ENOSPC mkfifo ${n0}/${n1} 0644
 umount /dev/md${n}

--- a/tests/open/19.t
+++ b/tests/open/19.t
@@ -24,7 +24,7 @@ while :; do
 	if [ $? -ne 0 ]; then
 		break
 	fi
-	i=`expr $i + 1`
+	i=$((i + 1))
 done
 expect ENOSPC open ${n0}/${i} O_RDONLY,O_CREAT 0644
 umount /dev/md${n}

--- a/tests/symlink/11.t
+++ b/tests/symlink/11.t
@@ -24,7 +24,7 @@ while :; do
 	if [ $? -ne 0 ]; then
 		break
 	fi
-	i=`expr $i + 1`
+	i=$((i + 1))
 done
 expect ENOSPC symlink test ${n0}/${n1}
 umount /dev/md${n}

--- a/tests/truncate/12.t
+++ b/tests/truncate/12.t
@@ -22,7 +22,7 @@ EFBIG|EINVAL)
 	;;
 *)
 	echo "not ok ${ntest}"
-	ntest=`expr ${ntest} + 1`
+	ntest=$((ntest + 1))
 	;;
 esac
 expect 0 unlink ${n0}


### PR DESCRIPTION
* Fix link count test

  This FreeBSD-only, UFS-only test verifies that attempting to create more
  links than permitted by the file system returns EMLINK, but has been
  broken ever since UFS_LINK_MAX was increased in FreeBSD 15 because it
  hardcodes the previous value of UFS_LINK_MAX, and the new value requires
  more space than the test allocates, so it ends up getting ENOSPC instead
  of EMLINK.
  
  * Switch to retrieving {PC_LINK_MAX} at runtime.
  
  * Stop the test when we reach {PC_LINK_MAX} links.  This ensures that
    we don't go on for hours if the actual limit turns out to be much
    higher than we anticipated.
  
  * Double the size of the test filesystem.
  
* Avoid needless use of expr

  Don't fork expr for simple arithmetic than can be performed by the shell.