### PR TITLE
symlink/03.t: mark test failure as expected on XFS due to target limit

### DIFF
--- a/tests/symlink/03.t
+++ b/tests/symlink/03.t
@@ -13,8 +13,23 @@ nx=`dirgen_max`
 nxx="${nx}x"
 
 mkdir -p "${nx%/*}"
+
+# On XFS, symlink targets are limited to 1024 bytes (vs PATH_MAX 4096).
+case "$fs" in
+	xfs|XFS)
+	todo Linux "XFS symlink target limit (1024) is smaller than PATH_MAX"
+	;;
+esac
 expect 0 symlink ${nx} ${n0}
+
+# Cleanup (unlink) will fail with ENOENT if the creation step above failed.
+case "$fs" in
+	xfs|XFS)
+	todo Linux "Cleanup fails because symlink creation failed on XFS"
+	;;
+esac
 expect 0 unlink ${n0}
+
 expect 0 symlink ${n0} ${nx}
 expect 0 unlink ${nx}
 expect ENAMETOOLONG symlink ${n0} ${nxx}


### PR DESCRIPTION
The symlink/03.t test assumes that a symbolic link can hold a target path equal to PATH_MAX (4096 bytes). However, XFS has an internal limit for symlink targets (MAXPATHLEN or 1024 bytes), which is smaller than the VFS PATH_MAX.

When running this test on XFS, the creation of a 4096-byte symlink (Test 1) fails with ENAMETOOLONG. Consequently, the cleanup step (Test 2) fails with ENOENT because the symlink was never created.
```
not ok 1 - tried 'symlink pjdfstest_f388d099a86baece05bd60b3ffdec961', expected 0, got ENAMETOOLONG
not ok 2 - tried 'unlink pjdfstest_f388d099a86baece05bd60b3ffdec961', expected 0, got ENOENT
```
This commit uses the 'todo' mechanism to mark these specific failures as expected behavior when running on XFS, ensuring the test suite passes on XFS while strictly enforcing limits on filesystems that support larger targets (e.g., ext4, Btrfs).

### Result on xfs
```
# prove -rv tests/symlink/03.t
tests/symlink/03.t ..
1..6
not ok 1 # TODO XFS symlink target limit (1024) is smaller than PATH_MAX
not ok 2 # TODO Cleanup fails because symlink creation failed on XFS
ok 3
ok 4
ok 5
ok 6
ok
All tests successful.
Files=1, Tests=6,  1 wallclock secs ( 0.04 usr  0.00 sys +  1.22 cusr  0.11 csys =  1.37 CPU)
Result: PASS

```
### Result on ext4
```
# prove -rv /home/pjdfstest/tests/symlink/03.t
/home/pjdfstest/tests/symlink/03.t ..
1..6
ok 1
ok 2
ok 3
ok 4
ok 5
ok 6
ok
All tests successful.
Files=1, Tests=6,  1 wallclock secs ( 0.03 usr  0.00 sys +  1.21 cusr  0.11 csys =  1.35 CPU)
Result: PASS
```